### PR TITLE
Remember me with OAuth does not work

### DIFF
--- a/backend/internal/handlers/oauth_handler.go
+++ b/backend/internal/handlers/oauth_handler.go
@@ -69,8 +69,11 @@ func (h *OAuthHandler) InitiateOAuth(c *fiber.Ctx) error {
 	// Get redirect URL (where to go after OAuth completes)
 	redirectTo := c.Query("redirect", "/dashboard")
 
-	// Generate authorization URL
-	authURL, err := h.oauthService.GetAuthURL(provider, redirectTo)
+	// Get remember_me preference
+	rememberMe := c.Query("remember_me", "false") == "true"
+
+	// Generate authorization URL (includes rememberMe in state token)
+	authURL, err := h.oauthService.GetAuthURL(provider, redirectTo, rememberMe)
 	if err != nil {
 		log.Printf("Failed to generate OAuth URL: %v", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -101,6 +104,9 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 		return h.redirectWithError(c, "Missing OAuth parameters")
 	}
 
+	// Extract remember_me preference from state token before validation
+	rememberMe := h.oauthService.GetRememberMeFromState(state)
+
 	// Exchange code for user info
 	userInfo, err := h.oauthService.ExchangeCode(c.Context(), provider, code, state)
 	if err != nil {
@@ -118,7 +124,7 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 	existingUser, err := h.userRepo.GetByProviderID(string(provider), userInfo.ProviderID)
 	if err == nil {
 		// User exists - log them in
-		return h.loginUser(c, existingUser)
+		return h.loginUser(c, existingUser, rememberMe)
 	}
 
 	// Check if user exists with this email (different provider)
@@ -143,7 +149,7 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 			return h.redirectWithError(c, "Failed to fetch user")
 		}
 
-		return h.loginUser(c, existingUser)
+		return h.loginUser(c, existingUser, rememberMe)
 	}
 
 	// User doesn't exist - create new account
@@ -166,7 +172,7 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 		return h.redirectWithError(c, "Failed to create account")
 	}
 
-	return h.loginUser(c, newUser)
+	return h.loginUser(c, newUser, rememberMe)
 }
 
 // LinkProvider links an OAuth provider to the currently logged-in user
@@ -291,9 +297,21 @@ func (h *OAuthHandler) GetProviderStatus(c *fiber.Ctx) error {
 }
 
 // Helper: loginUser creates a JWT token and sets the auth cookie
-func (h *OAuthHandler) loginUser(c *fiber.Ctx, user *models.User) error {
-	// Generate JWT token
-	token, err := h.authService.GenerateToken(user.ID, user.Email, user.Role)
+func (h *OAuthHandler) loginUser(c *fiber.Ctx, user *models.User, rememberMe bool) error {
+	// Generate token with appropriate expiration (same logic as regular login)
+	var token string
+	var err error
+	maxAge := 0 // Session cookie by default
+
+	if rememberMe {
+		// Remember me: 30 days for both token and cookie
+		maxAge = 30 * 24 * 60 * 60 // 30 days in seconds
+		token, err = h.authService.GenerateTokenWithExpiration(user.ID, user.Email, user.Role, 30*24*time.Hour)
+	} else {
+		// Session: 24 hours for token, session cookie (cleared on browser close)
+		token, err = h.authService.GenerateToken(user.ID, user.Email, user.Role)
+	}
+
 	if err != nil {
 		log.Printf("Failed to generate token: %v", err)
 		return h.redirectWithError(c, "Failed to generate auth token")
@@ -303,9 +321,9 @@ func (h *OAuthHandler) loginUser(c *fiber.Ctx, user *models.User) error {
 	c.Cookie(&fiber.Cookie{
 		Name:     "auth_token",
 		Value:    token,
-		Expires:  time.Now().Add(24 * time.Hour),
+		MaxAge:   maxAge,
 		HTTPOnly: true,
-		Secure:   h.getCookieSecure(), // Consistent with regular login
+		Secure:   h.getCookieSecure(),
 		SameSite: "Lax",
 		Domain:   h.getCookieDomain(),
 	})

--- a/backend/internal/handlers/oauth_handler_test.go
+++ b/backend/internal/handlers/oauth_handler_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -130,6 +131,68 @@ func TestOAuthHandler_HandleCallback_MissingParameters(t *testing.T) {
 			resp, err := app.Test(req)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestOAuthHandler_InitiateOAuth_RememberMe(t *testing.T) {
+	// Test that remember_me query parameter is correctly parsed
+	app := fiber.New()
+	app.Get("/oauth/:provider", func(c *fiber.Ctx) error {
+		rememberMe := c.Query("remember_me", "false") == "true"
+		return c.JSON(fiber.Map{
+			"remember_me": rememberMe,
+		})
+	})
+
+	tests := []struct {
+		name               string
+		queryParams        string
+		expectedRememberMe bool
+	}{
+		{
+			name:               "No remember_me param defaults to false",
+			queryParams:        "",
+			expectedRememberMe: false,
+		},
+		{
+			name:               "remember_me=true",
+			queryParams:        "?remember_me=true",
+			expectedRememberMe: true,
+		},
+		{
+			name:               "remember_me=false",
+			queryParams:        "?remember_me=false",
+			expectedRememberMe: false,
+		},
+		{
+			name:               "remember_me with other params",
+			queryParams:        "?redirect=/settings&remember_me=true",
+			expectedRememberMe: true,
+		},
+		{
+			name:               "Invalid remember_me value treated as false",
+			queryParams:        "?remember_me=yes",
+			expectedRememberMe: false,
+		},
+		{
+			name:               "remember_me=1 treated as false (must be 'true')",
+			queryParams:        "?remember_me=1",
+			expectedRememberMe: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/oauth/google"+tt.queryParams, nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+			var result map[string]interface{}
+			err = json.NewDecoder(resp.Body).Decode(&result)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedRememberMe, result["remember_me"])
 		})
 	}
 }

--- a/backend/internal/services/oauth_service.go
+++ b/backend/internal/services/oauth_service.go
@@ -85,14 +85,14 @@ func NewOAuthService(
 }
 
 // GetAuthURL generates the OAuth authorization URL with state token
-func (s *OAuthService) GetAuthURL(provider models.OAuthProvider, redirectTo string) (string, error) {
+func (s *OAuthService) GetAuthURL(provider models.OAuthProvider, redirectTo string, rememberMe bool) (string, error) {
 	config, ok := s.configs[provider]
 	if !ok {
 		return "", fmt.Errorf("%w: %s", ErrInvalidProvider, provider)
 	}
 
-	// Generate state token for CSRF protection
-	stateToken, err := s.generateStateToken(provider, redirectTo)
+	// Generate state token for CSRF protection (includes rememberMe preference)
+	stateToken, err := s.generateStateToken(provider, redirectTo, rememberMe)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate state token: %w", err)
 	}
@@ -131,16 +131,43 @@ func (s *OAuthService) ExchangeCode(ctx context.Context, provider models.OAuthPr
 }
 
 // generateStateToken creates a JWT state token for CSRF protection
-func (s *OAuthService) generateStateToken(provider models.OAuthProvider, redirectTo string) (string, error) {
+func (s *OAuthService) generateStateToken(provider models.OAuthProvider, redirectTo string, rememberMe bool) (string, error) {
 	claims := jwt.MapClaims{
 		"provider":    string(provider),
 		"redirect_to": redirectTo,
+		"remember_me": rememberMe,
 		"created_at":  time.Now().Unix(),
 		"exp":         time.Now().Add(5 * time.Minute).Unix(), // 5 minute expiry
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(s.stateSecret))
+}
+
+// GetRememberMeFromState extracts the remember_me preference from the state token
+func (s *OAuthService) GetRememberMeFromState(stateToken string) bool {
+	token, err := jwt.Parse(stateToken, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(s.stateSecret), nil
+	})
+
+	if err != nil {
+		return false
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return false
+	}
+
+	rememberMe, ok := claims["remember_me"].(bool)
+	if !ok {
+		return false
+	}
+
+	return rememberMe
 }
 
 // validateStateToken validates the state token and extracts provider

--- a/backend/internal/services/oauth_service_test.go
+++ b/backend/internal/services/oauth_service_test.go
@@ -1,0 +1,121 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/nimbus/backend/internal/models"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func TestOAuthService_StateToken_RememberMe(t *testing.T) {
+	// Create a minimal OAuth service with just the state secret
+	service := &OAuthService{
+		configs:     make(map[models.OAuthProvider]*oauth2.Config),
+		stateSecret: "test-secret-key-for-testing-32ch",
+	}
+
+	tests := []struct {
+		name       string
+		rememberMe bool
+	}{
+		{
+			name:       "State token with remember_me=true",
+			rememberMe: true,
+		},
+		{
+			name:       "State token with remember_me=false",
+			rememberMe: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Generate state token
+			token, err := service.generateStateToken(models.ProviderGoogle, "/dashboard", tt.rememberMe)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, token)
+
+			// Extract remember_me from token
+			extracted := service.GetRememberMeFromState(token)
+			assert.Equal(t, tt.rememberMe, extracted)
+		})
+	}
+}
+
+func TestOAuthService_GetRememberMeFromState_InvalidToken(t *testing.T) {
+	service := &OAuthService{
+		configs:     make(map[models.OAuthProvider]*oauth2.Config),
+		stateSecret: "test-secret-key-for-testing-32ch",
+	}
+
+	tests := []struct {
+		name     string
+		token    string
+		expected bool
+	}{
+		{
+			name:     "Empty token",
+			token:    "",
+			expected: false,
+		},
+		{
+			name:     "Invalid token format",
+			token:    "not-a-valid-jwt-token",
+			expected: false,
+		},
+		{
+			name:     "Token with wrong secret",
+			token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZW1lbWJlcl9tZSI6dHJ1ZX0.invalid",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.GetRememberMeFromState(tt.token)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestOAuthService_GetRememberMeFromState_DifferentSecret(t *testing.T) {
+	// Create two services with different secrets
+	service1 := &OAuthService{
+		configs:     make(map[models.OAuthProvider]*oauth2.Config),
+		stateSecret: "secret-one-for-testing-32chars!",
+	}
+	service2 := &OAuthService{
+		configs:     make(map[models.OAuthProvider]*oauth2.Config),
+		stateSecret: "secret-two-for-testing-32chars!",
+	}
+
+	// Generate token with service1
+	token, err := service1.generateStateToken(models.ProviderGoogle, "/dashboard", true)
+	assert.NoError(t, err)
+
+	// Verify service1 can read it
+	assert.True(t, service1.GetRememberMeFromState(token))
+
+	// Verify service2 cannot read it (wrong secret)
+	assert.False(t, service2.GetRememberMeFromState(token))
+}
+
+func TestOAuthService_StateToken_PreservesOtherClaims(t *testing.T) {
+	service := &OAuthService{
+		configs:     make(map[models.OAuthProvider]*oauth2.Config),
+		stateSecret: "test-secret-key-for-testing-32ch",
+	}
+
+	// Generate token and validate it still works for state validation
+	token, err := service.generateStateToken(models.ProviderGitHub, "/settings", true)
+	assert.NoError(t, err)
+
+	// State validation should still pass
+	err = service.validateStateToken(token, models.ProviderGitHub)
+	assert.NoError(t, err)
+
+	// Wrong provider should fail
+	err = service.validateStateToken(token, models.ProviderGoogle)
+	assert.Error(t, err)
+}

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -256,13 +256,13 @@ function LoginForm() {
 
           <div className="space-y-3">
             {oauthProviders.includes('google') && (
-              <OAuthButton provider="google" redirectTo="/dashboard" />
+              <OAuthButton provider="google" redirectTo="/dashboard" rememberMe={rememberMe} />
             )}
             {oauthProviders.includes('github') && (
-              <OAuthButton provider="github" redirectTo="/dashboard" />
+              <OAuthButton provider="github" redirectTo="/dashboard" rememberMe={rememberMe} />
             )}
             {oauthProviders.includes('discord') && (
-              <OAuthButton provider="discord" redirectTo="/dashboard" />
+              <OAuthButton provider="discord" redirectTo="/dashboard" rememberMe={rememberMe} />
             )}
           </div>
         </>

--- a/frontend/components/OAuthButton.tsx
+++ b/frontend/components/OAuthButton.tsx
@@ -10,6 +10,7 @@ import DiscordIcon from './icons/DiscordIcon'
 interface OAuthButtonProps {
   provider: OAuthProvider
   redirectTo?: string
+  rememberMe?: boolean
   className?: string
 }
 
@@ -40,14 +41,19 @@ const providerConfig = {
   },
 }
 
-export default function OAuthButton({ provider, redirectTo, className = '' }: OAuthButtonProps) {
+export default function OAuthButton({
+  provider,
+  redirectTo,
+  rememberMe,
+  className = '',
+}: OAuthButtonProps) {
   const [isLoading, setIsLoading] = useState(false)
   const config = providerConfig[provider]
   const Icon = config.icon
 
   const handleClick = () => {
     setIsLoading(true)
-    api.initiateOAuth(provider, redirectTo)
+    api.initiateOAuth(provider, redirectTo, rememberMe)
   }
 
   return (

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -327,15 +327,18 @@ class ApiClient {
   /**
    * Initiate OAuth login flow - redirects to provider
    */
-  initiateOAuth(provider: OAuthProvider, redirectTo?: string): void {
+  initiateOAuth(provider: OAuthProvider, redirectTo?: string, rememberMe?: boolean): void {
     const apiUrl = getApiUrl()
     if (!apiUrl) {
       console.error('API URL not configured for OAuth')
       return
     }
 
-    const queryParams = redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ''
-    window.location.href = `${apiUrl}/auth/oauth/${provider}${queryParams}`
+    const params = new URLSearchParams()
+    if (redirectTo) params.set('redirect', redirectTo)
+    if (rememberMe) params.set('remember_me', 'true')
+    const queryString = params.toString()
+    window.location.href = `${apiUrl}/auth/oauth/${provider}${queryString ? '?' + queryString : ''}`
   }
 
   /**


### PR DESCRIPTION
The JWT token expires in 24h while Remember me is checked, this should be 1 month like the regular login has. The problem is that we did not pass the rememberMe param for the OAuth method. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Remember Me" option to OAuth login flow, allowing users to maintain longer session durations when enabled.
  * OAuth sign-in now supports configurable session expiration based on remember preference.

* **Tests**
  * Added comprehensive test coverage for remember me functionality across OAuth authentication and state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->