### PR TITLE
Fix/146 profile pictures broken

### DIFF
--- a/backend/internal/handlers/oauth_handler.go
+++ b/backend/internal/handlers/oauth_handler.go
@@ -115,7 +115,14 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 	// Check if user already exists with this OAuth provider
 	existingUser, err := h.userRepo.GetByProviderID(string(provider), userInfo.ProviderID)
 	if err == nil {
-		// User exists - log them in
+		// Refresh the cached avatar URL — providers (Discord especially)
+		// rotate the URL when the user changes their avatar, so without
+		// this the stored URL goes stale and 404s on the frontend.
+		if existingUser.AvatarURL == nil || *existingUser.AvatarURL != userInfo.AvatarURL {
+			if updateErr := h.userRepo.UpdateAvatar(existingUser.ID, &userInfo.AvatarURL); updateErr != nil {
+				log.Printf("Failed to refresh avatar for user %s: %v", existingUser.ID, updateErr)
+			}
+		}
 		return h.loginUser(c, existingUser, rememberMe)
 	}
 

--- a/backend/internal/handlers/oauth_handler.go
+++ b/backend/internal/handlers/oauth_handler.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -117,8 +118,10 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 	if err == nil {
 		// Refresh the cached avatar URL — providers (Discord especially)
 		// rotate the URL when the user changes their avatar, so without
-		// this the stored URL goes stale and 404s on the frontend.
-		if existingUser.AvatarURL == nil || *existingUser.AvatarURL != userInfo.AvatarURL {
+		// this the stored URL goes stale and 404s on the frontend. Skip
+		// if the user has a locally-uploaded avatar so we don't clobber it.
+		isLocalUpload := existingUser.AvatarURL != nil && strings.HasPrefix(*existingUser.AvatarURL, "/uploads/")
+		if !isLocalUpload && (existingUser.AvatarURL == nil || *existingUser.AvatarURL != userInfo.AvatarURL) {
 			if updateErr := h.userRepo.UpdateAvatar(existingUser.ID, &userInfo.AvatarURL); updateErr != nil {
 				log.Printf("Failed to refresh avatar for user %s: %v", existingUser.ID, updateErr)
 			}

--- a/backend/internal/handlers/oauth_handler.go
+++ b/backend/internal/handlers/oauth_handler.go
@@ -132,12 +132,17 @@ func (h *OAuthHandler) HandleCallback(c *fiber.Ctx) error {
 	// Check if user exists with this email (different provider)
 	existingUser, err = h.userRepo.GetByEmail(userInfo.Email)
 	if err == nil {
-		// Email exists - link this provider to the existing account
+		// Email exists - link this provider to the existing account.
+		// Preserve a locally-uploaded avatar; otherwise adopt the provider's.
+		avatarToStore := &userInfo.AvatarURL
+		if existingUser.AvatarURL != nil && strings.HasPrefix(*existingUser.AvatarURL, "/uploads/") {
+			avatarToStore = existingUser.AvatarURL
+		}
 		err = h.userRepo.LinkOAuthProvider(
 			existingUser.ID,
 			string(provider),
 			userInfo.ProviderID,
-			&userInfo.AvatarURL,
+			avatarToStore,
 		)
 		if err != nil {
 			log.Printf("Failed to link OAuth provider: %v", err)

--- a/backend/internal/handlers/oauth_handler_test.go
+++ b/backend/internal/handlers/oauth_handler_test.go
@@ -398,26 +398,46 @@ func TestOAuthHandler_RegistrationEnabledCheck(t *testing.T) {
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 }
 
-func TestOAuthHandler_ExistingUserAvatarRefresh(t *testing.T) {
-	// On every OAuth login, the handler should refresh the cached avatar URL
-	// so that providers (e.g. Discord) rotating the URL after an avatar change
-	// don't leave the user with a stale, 404-ing image.
-
-	db := setupOAuthTestDB(t)
-	defer db.Close()
-
+// runAvatarRefreshSim simulates the avatar-refresh slice of HandleCallback
+// against the seeded user and returns the user's avatar_url after the call.
+func runAvatarRefreshSim(t *testing.T, db *sql.DB, providerURL string) *string {
+	t.Helper()
 	userRepo := repository.NewUserRepository(db)
 
-	staleURL := "https://cdn.discordapp.com/avatars/123/old_hash.png"
-	freshURL := "https://cdn.discordapp.com/avatars/123/new_hash.png"
+	app := fiber.New()
+	app.Get("/oauth/:provider/callback", func(c *fiber.Ctx) error {
+		existingUser, err := userRepo.GetByProviderID("discord", "123")
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		}
+		isLocalUpload := existingUser.AvatarURL != nil &&
+			len(*existingUser.AvatarURL) >= 9 && (*existingUser.AvatarURL)[:9] == "/uploads/"
+		if !isLocalUpload && (existingUser.AvatarURL == nil || *existingUser.AvatarURL != providerURL) {
+			if err := userRepo.UpdateAvatar(existingUser.ID, &providerURL); err != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+			}
+		}
+		return c.SendStatus(fiber.StatusOK)
+	})
 
+	resp, err := app.Test(httptest.NewRequest("GET", "/oauth/discord/callback", nil))
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	refreshed, err := userRepo.GetByID("user-1")
+	assert.NoError(t, err)
+	return refreshed.AvatarURL
+}
+
+// seedDiscordUser inserts a Discord OAuth user with the given starting avatar.
+func seedDiscordUser(t *testing.T, db *sql.DB, startingAvatar string) {
+	t.Helper()
 	user := &models.User{
 		ID:         "user-1",
 		Email:      "discord@example.com",
 		Name:       "Discord User",
 		Provider:   "discord",
 		ProviderID: stringPtr("123"),
-		AvatarURL:  &staleURL,
 		Role:       "user",
 		CreatedAt:  time.Now(),
 		UpdatedAt:  time.Now(),
@@ -425,35 +445,53 @@ func TestOAuthHandler_ExistingUserAvatarRefresh(t *testing.T) {
 	if _, err := db.Exec(`
 		INSERT INTO users (id, email, name, provider, provider_id, avatar_url, role, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, user.ID, user.Email, user.Name, user.Provider, user.ProviderID, *user.AvatarURL, user.Role, user.CreatedAt, user.UpdatedAt); err != nil {
+	`, user.ID, user.Email, user.Name, user.Provider, user.ProviderID, startingAvatar, user.Role, user.CreatedAt, user.UpdatedAt); err != nil {
 		t.Fatalf("Failed to seed user: %v", err)
 	}
+}
 
-	// Simulate the relevant slice of HandleCallback: lookup existing user,
-	// refresh the avatar URL when the provider's value differs.
-	app := fiber.New()
-	app.Get("/oauth/:provider/callback", func(c *fiber.Ctx) error {
-		existingUser, err := userRepo.GetByProviderID("discord", "123")
-		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
-		}
-		if existingUser.AvatarURL == nil || *existingUser.AvatarURL != freshURL {
-			if err := userRepo.UpdateAvatar(existingUser.ID, &freshURL); err != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
-			}
-		}
-		return c.SendStatus(fiber.StatusOK)
-	})
+func TestOAuthHandler_AvatarRefresh_StaleURLIsRefreshed(t *testing.T) {
+	// On every OAuth login, the handler should refresh the cached avatar URL
+	// so that providers (e.g. Discord) rotating the URL after an avatar change
+	// don't leave the user with a stale, 404-ing image.
+	db := setupOAuthTestDB(t)
+	defer db.Close()
 
-	req := httptest.NewRequest("GET", "/oauth/discord/callback", nil)
-	resp, err := app.Test(req)
-	assert.NoError(t, err)
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	staleURL := "https://cdn.discordapp.com/avatars/123/old_hash.png"
+	freshURL := "https://cdn.discordapp.com/avatars/123/new_hash.png"
+	seedDiscordUser(t, db, staleURL)
 
-	refreshed, err := userRepo.GetByID(user.ID)
-	assert.NoError(t, err)
-	assert.NotNil(t, refreshed.AvatarURL)
-	assert.Equal(t, freshURL, *refreshed.AvatarURL)
+	got := runAvatarRefreshSim(t, db, freshURL)
+	assert.NotNil(t, got)
+	assert.Equal(t, freshURL, *got)
+}
+
+func TestOAuthHandler_AvatarRefresh_MatchingURLIsSkipped(t *testing.T) {
+	// When the provider returns the same URL we already have, nothing should change.
+	db := setupOAuthTestDB(t)
+	defer db.Close()
+
+	url := "https://cdn.discordapp.com/avatars/123/hash.png"
+	seedDiscordUser(t, db, url)
+
+	got := runAvatarRefreshSim(t, db, url)
+	assert.NotNil(t, got)
+	assert.Equal(t, url, *got)
+}
+
+func TestOAuthHandler_AvatarRefresh_LocalUploadIsPreserved(t *testing.T) {
+	// If the user has a locally-uploaded avatar (path under /uploads/), the
+	// OAuth refresh must not clobber it on subsequent logins.
+	db := setupOAuthTestDB(t)
+	defer db.Close()
+
+	localPath := "/uploads/avatars/custom.png"
+	providerURL := "https://cdn.discordapp.com/avatars/123/hash.png"
+	seedDiscordUser(t, db, localPath)
+
+	got := runAvatarRefreshSim(t, db, providerURL)
+	assert.NotNil(t, got)
+	assert.Equal(t, localPath, *got)
 }
 
 func stringPtr(s string) *string { return &s }

--- a/backend/internal/handlers/oauth_handler_test.go
+++ b/backend/internal/handlers/oauth_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/nimbus/backend/internal/models"
 	"github.com/nimbus/backend/internal/repository"
 	"github.com/stretchr/testify/assert"
 
@@ -396,6 +397,66 @@ func TestOAuthHandler_RegistrationEnabledCheck(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 }
+
+func TestOAuthHandler_ExistingUserAvatarRefresh(t *testing.T) {
+	// On every OAuth login, the handler should refresh the cached avatar URL
+	// so that providers (e.g. Discord) rotating the URL after an avatar change
+	// don't leave the user with a stale, 404-ing image.
+
+	db := setupOAuthTestDB(t)
+	defer db.Close()
+
+	userRepo := repository.NewUserRepository(db)
+
+	staleURL := "https://cdn.discordapp.com/avatars/123/old_hash.png"
+	freshURL := "https://cdn.discordapp.com/avatars/123/new_hash.png"
+
+	user := &models.User{
+		ID:         "user-1",
+		Email:      "discord@example.com",
+		Name:       "Discord User",
+		Provider:   "discord",
+		ProviderID: stringPtr("123"),
+		AvatarURL:  &staleURL,
+		Role:       "user",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, provider, provider_id, avatar_url, role, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, user.ID, user.Email, user.Name, user.Provider, user.ProviderID, *user.AvatarURL, user.Role, user.CreatedAt, user.UpdatedAt); err != nil {
+		t.Fatalf("Failed to seed user: %v", err)
+	}
+
+	// Simulate the relevant slice of HandleCallback: lookup existing user,
+	// refresh the avatar URL when the provider's value differs.
+	app := fiber.New()
+	app.Get("/oauth/:provider/callback", func(c *fiber.Ctx) error {
+		existingUser, err := userRepo.GetByProviderID("discord", "123")
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		}
+		if existingUser.AvatarURL == nil || *existingUser.AvatarURL != freshURL {
+			if err := userRepo.UpdateAvatar(existingUser.ID, &freshURL); err != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+			}
+		}
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/oauth/discord/callback", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	refreshed, err := userRepo.GetByID(user.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, refreshed.AvatarURL)
+	assert.Equal(t, freshURL, *refreshed.AvatarURL)
+}
+
+func stringPtr(s string) *string { return &s }
 
 func TestOAuthHandler_ExistingUserBypassesRegistrationCheck(t *testing.T) {
 	// This test verifies existing OAuth users can log in even when registration is disabled

--- a/backend/internal/handlers/oauth_handler_test.go
+++ b/backend/internal/handlers/oauth_handler_test.go
@@ -479,6 +479,49 @@ func TestOAuthHandler_AvatarRefresh_MatchingURLIsSkipped(t *testing.T) {
 	assert.Equal(t, url, *got)
 }
 
+func TestOAuthHandler_LinkProvider_LocalUploadIsPreserved(t *testing.T) {
+	// When a local-account user signs in via OAuth with a matching email, the
+	// link path must preserve their locally-uploaded avatar instead of
+	// overwriting it with the provider's URL.
+	db := setupOAuthTestDB(t)
+	defer db.Close()
+
+	userRepo := repository.NewUserRepository(db)
+
+	localPath := "/uploads/avatars/custom.png"
+	providerURL := "https://cdn.discordapp.com/avatars/123/hash.png"
+	user := &models.User{
+		ID:        "user-1",
+		Email:     "linker@example.com",
+		Name:      "Linker",
+		Provider:  "local",
+		AvatarURL: &localPath,
+		Role:      "user",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, provider, avatar_url, role, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, user.ID, user.Email, user.Name, user.Provider, *user.AvatarURL, user.Role, user.CreatedAt, user.UpdatedAt); err != nil {
+		t.Fatalf("Failed to seed user: %v", err)
+	}
+
+	// Mirror the link slice of HandleCallback.
+	avatarToStore := &providerURL
+	if user.AvatarURL != nil && len(*user.AvatarURL) >= 9 && (*user.AvatarURL)[:9] == "/uploads/" {
+		avatarToStore = user.AvatarURL
+	}
+	if err := userRepo.LinkOAuthProvider(user.ID, "discord", "123", avatarToStore); err != nil {
+		t.Fatalf("LinkOAuthProvider failed: %v", err)
+	}
+
+	linked, err := userRepo.GetByID(user.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, linked.AvatarURL)
+	assert.Equal(t, localPath, *linked.AvatarURL)
+}
+
 func TestOAuthHandler_AvatarRefresh_LocalUploadIsPreserved(t *testing.T) {
 	// If the user has a locally-uploaded avatar (path under /uploads/), the
 	// OAuth refresh must not clobber it on subsequent logins.

--- a/backend/internal/repository/user_repository_test.go
+++ b/backend/internal/repository/user_repository_test.go
@@ -104,6 +104,49 @@ func TestUserRepository_UpdateRole(t *testing.T) {
 	})
 }
 
+func TestUserRepository_UpdateAvatar(t *testing.T) {
+	db := setupUserTestDB(t)
+	defer db.Close()
+
+	repo := NewUserRepository(db)
+
+	user := &models.User{
+		Email:     "avatar@example.com",
+		Name:      "Avatar User",
+		Provider:  "discord",
+		AvatarURL: stringPtr("https://cdn.discordapp.com/avatars/123/old_hash.png"),
+		Role:      "user",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := repo.Create(user); err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+
+	t.Run("Refresh stale avatar URL", func(t *testing.T) {
+		newURL := "https://cdn.discordapp.com/avatars/123/new_hash.png"
+		if err := repo.UpdateAvatar(user.ID, &newURL); err != nil {
+			t.Fatalf("UpdateAvatar failed: %v", err)
+		}
+
+		updated, err := repo.GetByID(user.ID)
+		if err != nil {
+			t.Fatalf("Failed to fetch updated user: %v", err)
+		}
+		if updated.AvatarURL == nil || *updated.AvatarURL != newURL {
+			t.Errorf("Expected avatar %q, got %v", newURL, updated.AvatarURL)
+		}
+	})
+
+	t.Run("Update avatar for non-existent user", func(t *testing.T) {
+		url := "https://example.com/avatar.png"
+		if err := repo.UpdateAvatar("non-existent-id", &url); err == nil {
+			t.Error("Expected error for non-existent user, got nil")
+		}
+	})
+}
+
 func TestUserRepository_Delete(t *testing.T) {
 	db := setupUserTestDB(t)
 	defer db.Close()

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import Image from 'next/image'
 import { api } from '@/lib/api'
-import { getApiUrl } from '@/lib/utils/api-url'
 import type { User } from '@/types'
-import { UserCircleIcon } from '@heroicons/react/24/outline'
+import UserAvatar from '@/components/UserAvatar'
 import ChangePasswordSection from '@/components/ChangePasswordSection'
 import DangerZoneSection from '@/components/DangerZoneSection'
 import GoogleIcon from '@/components/icons/GoogleIcon'
@@ -17,7 +15,6 @@ export default function ProfilePage() {
   const [isLoading, setIsLoading] = useState(true)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadError, setUploadError] = useState('')
-  const [avatarFailed, setAvatarFailed] = useState(false)
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -25,7 +22,6 @@ export default function ProfilePage() {
         const response = await api.getCurrentUser()
         if (response.data) {
           setUser(response.data)
-          setAvatarFailed(false)
         }
       } catch (error) {
         console.error('Failed to fetch user:', error)
@@ -62,7 +58,6 @@ export default function ProfilePage() {
     const response = await api.uploadAvatar(formData)
     if (response.data) {
       setUser(response.data)
-      setAvatarFailed(false)
     } else if (response.error) {
       setUploadError(response.error.message)
     }
@@ -96,14 +91,6 @@ export default function ProfilePage() {
       default:
         return provider
     }
-  }
-
-  const getAvatarUrl = (avatarUrl: string | undefined) => {
-    if (!avatarUrl) return undefined
-    // If it's a full URL (OAuth provider), return as-is
-    if (avatarUrl.startsWith('http')) return avatarUrl
-    // If it's a relative path (local upload), prepend API URL
-    return getApiUrl() + avatarUrl
   }
 
   if (isLoading) {
@@ -146,21 +133,12 @@ export default function ProfilePage() {
               Profile Picture
             </label>
             <div className="flex items-center space-x-4">
-              {user?.avatar_url && getAvatarUrl(user.avatar_url) && !avatarFailed ? (
-                <Image
-                  src={getAvatarUrl(user.avatar_url)!}
-                  alt={user.name}
-                  width={80}
-                  height={80}
-                  className="h-20 w-20 rounded-full object-cover"
-                  onError={() => setAvatarFailed(true)}
-                />
-              ) : (
-                <UserCircleIcon
-                  className="h-20 w-20"
-                  style={{ color: 'var(--color-text-secondary)' }}
-                />
-              )}
+              <UserAvatar
+                avatarUrl={user?.avatar_url}
+                name={user?.name || 'User'}
+                size={80}
+                className="h-20 w-20"
+              />
 
               {user?.provider === 'local' ? (
                 <div className="flex-1">

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -17,6 +17,7 @@ export default function ProfilePage() {
   const [isLoading, setIsLoading] = useState(true)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadError, setUploadError] = useState('')
+  const [avatarFailed, setAvatarFailed] = useState(false)
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -24,6 +25,7 @@ export default function ProfilePage() {
         const response = await api.getCurrentUser()
         if (response.data) {
           setUser(response.data)
+          setAvatarFailed(false)
         }
       } catch (error) {
         console.error('Failed to fetch user:', error)
@@ -60,6 +62,7 @@ export default function ProfilePage() {
     const response = await api.uploadAvatar(formData)
     if (response.data) {
       setUser(response.data)
+      setAvatarFailed(false)
     } else if (response.error) {
       setUploadError(response.error.message)
     }
@@ -143,13 +146,14 @@ export default function ProfilePage() {
               Profile Picture
             </label>
             <div className="flex items-center space-x-4">
-              {user?.avatar_url && getAvatarUrl(user.avatar_url) ? (
+              {user?.avatar_url && getAvatarUrl(user.avatar_url) && !avatarFailed ? (
                 <Image
                   src={getAvatarUrl(user.avatar_url)!}
                   alt={user.name}
                   width={80}
                   height={80}
                   className="h-20 w-20 rounded-full object-cover"
+                  onError={() => setAvatarFailed(true)}
                 />
               ) : (
                 <UserCircleIcon

--- a/frontend/components/UserAvatar.tsx
+++ b/frontend/components/UserAvatar.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { UserCircleIcon } from '@heroicons/react/24/outline'
+import { getApiUrl } from '@/lib/utils/api-url'
+
+const resolveAvatarUrl = (avatarUrl: string | null | undefined): string | undefined => {
+  if (!avatarUrl) return undefined
+  // OAuth providers return a full URL; local uploads are stored as a
+  // relative path that needs the API origin prepended.
+  if (avatarUrl.startsWith('http')) return avatarUrl
+  return getApiUrl() + avatarUrl
+}
+
+interface UserAvatarProps {
+  avatarUrl: string | null | undefined
+  name: string
+  size: number
+  className?: string
+}
+
+export default function UserAvatar({ avatarUrl, name, size, className = '' }: UserAvatarProps) {
+  const resolved = resolveAvatarUrl(avatarUrl)
+  const [failedUrl, setFailedUrl] = useState<string | null>(null)
+  const failed = failedUrl !== null && failedUrl === resolved
+
+  const sizeClass = `rounded-full object-cover ${className}`.trim()
+
+  if (resolved && !failed) {
+    return (
+      <Image
+        src={resolved}
+        alt={name}
+        width={size}
+        height={size}
+        className={sizeClass}
+        onError={() => setFailedUrl(resolved)}
+      />
+    )
+  }
+
+  return (
+    <UserCircleIcon
+      className={className || undefined}
+      style={{
+        color: 'var(--color-text-secondary)',
+        width: size,
+        height: size,
+      }}
+    />
+  )
+}

--- a/frontend/components/UserMenu.tsx
+++ b/frontend/components/UserMenu.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import {
   UserCircleIcon,
   ArrowRightOnRectangleIcon,
@@ -10,7 +9,7 @@ import {
   ChevronDownIcon,
 } from '@heroicons/react/24/outline'
 import { api } from '@/lib/api'
-import { getApiUrl } from '@/lib/utils/api-url'
+import UserAvatar from '@/components/UserAvatar'
 import { useHoverStyle, hoverStyles } from '@/hooks/useHoverStyle'
 import type { User } from '@/types'
 
@@ -18,7 +17,6 @@ export default function UserMenu() {
   const [user, setUser] = useState<User | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
-  const [avatarFailed, setAvatarFailed] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
   const menuItemHover = useHoverStyle(hoverStyles.menuItem)
@@ -29,7 +27,6 @@ export default function UserMenu() {
       const response = await api.getCurrentUser()
       if (response.data) {
         setUser(response.data)
-        setAvatarFailed(false)
       }
       setIsLoading(false)
     }
@@ -55,14 +52,6 @@ export default function UserMenu() {
     setIsOpen(false)
     router.push('/settings/profile')
   }, [router])
-
-  const getAvatarUrl = (avatarUrl: string | undefined) => {
-    if (!avatarUrl) return undefined
-    // If it's a full URL (OAuth provider), return as-is
-    if (avatarUrl.startsWith('http')) return avatarUrl
-    // If it's a relative path (local upload), prepend API URL
-    return getApiUrl() + avatarUrl
-  }
 
   if (isLoading) {
     return (
@@ -97,18 +86,12 @@ export default function UserMenu() {
           }
         }}
       >
-        {user?.avatar_url && getAvatarUrl(user.avatar_url) && !avatarFailed ? (
-          <Image
-            src={getAvatarUrl(user.avatar_url)!}
-            alt={user.name}
-            width={32}
-            height={32}
-            className="h-8 w-8 rounded-full object-cover"
-            onError={() => setAvatarFailed(true)}
-          />
-        ) : (
-          <UserCircleIcon className="h-8 w-8" style={{ color: 'var(--color-text-secondary)' }} />
-        )}
+        <UserAvatar
+          avatarUrl={user?.avatar_url}
+          name={user?.name || 'User'}
+          size={32}
+          className="h-8 w-8"
+        />
         <div className="hidden text-left sm:block">
           <div className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
             {user?.name || 'User'}

--- a/frontend/components/UserMenu.tsx
+++ b/frontend/components/UserMenu.tsx
@@ -18,6 +18,7 @@ export default function UserMenu() {
   const [user, setUser] = useState<User | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
+  const [avatarFailed, setAvatarFailed] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
   const menuItemHover = useHoverStyle(hoverStyles.menuItem)
@@ -28,6 +29,7 @@ export default function UserMenu() {
       const response = await api.getCurrentUser()
       if (response.data) {
         setUser(response.data)
+        setAvatarFailed(false)
       }
       setIsLoading(false)
     }
@@ -95,13 +97,14 @@ export default function UserMenu() {
           }
         }}
       >
-        {user?.avatar_url && getAvatarUrl(user.avatar_url) ? (
+        {user?.avatar_url && getAvatarUrl(user.avatar_url) && !avatarFailed ? (
           <Image
             src={getAvatarUrl(user.avatar_url)!}
             alt={user.name}
             width={32}
             height={32}
             className="h-8 w-8 rounded-full object-cover"
+            onError={() => setAvatarFailed(true)}
           />
         ) : (
           <UserCircleIcon className="h-8 w-8" style={{ color: 'var(--color-text-secondary)' }} />


### PR DESCRIPTION
Refs #146

Discord (and other providers) rotate the avatar URL when the user changes their picture, so the URL we cached at signup goes stale and 404s. Refresh avatar_url from the provider on every successful OAuth login to keep it in sync.

Also add an onError fallback to the avatar <Image> in UserMenu and the profile page so a broken URL falls through to the UserCircleIcon placeholder instead of rendering the cropped alt text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth users' avatars now automatically refresh from their provider (Discord, etc.) when logging in, keeping profiles up-to-date.
  * Locally uploaded avatars are preserved and won't be overwritten by provider data.

* **Improvements**
  * Avatar display is now consistent throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Turbootzz/Nimbus/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->