### PR TITLE
fix(avatar): skip Next.js image optimization for remote URLs

### DIFF
--- a/frontend/components/UserAvatar.tsx
+++ b/frontend/components/UserAvatar.tsx
@@ -28,6 +28,12 @@ export default function UserAvatar({ avatarUrl, name, size, className = '' }: Us
   const sizeClass = `rounded-full object-cover ${className}`.trim()
 
   if (resolved && !failed) {
+    // Skip Next.js image optimization for remote provider URLs. When a
+    // cached OAuth avatar goes stale (Discord rotates the hash on change)
+    // the optimizer would otherwise log an upstream 404 on every render.
+    // Bypassing it lets the browser try directly and fail silently into
+    // the icon fallback below until the next OAuth login refreshes the URL.
+    const isRemote = resolved.startsWith('http')
     return (
       <Image
         src={resolved}
@@ -35,6 +41,7 @@ export default function UserAvatar({ avatarUrl, name, size, className = '' }: Us
         width={size}
         height={size}
         className={sizeClass}
+        unoptimized={isRemote}
         onError={() => setFailedUrl(resolved)}
       />
     )

--- a/frontend/components/UserAvatar.tsx
+++ b/frontend/components/UserAvatar.tsx
@@ -28,12 +28,14 @@ export default function UserAvatar({ avatarUrl, name, size, className = '' }: Us
   const sizeClass = `rounded-full object-cover ${className}`.trim()
 
   if (resolved && !failed) {
-    // Skip Next.js image optimization for remote provider URLs. When a
-    // cached OAuth avatar goes stale (Discord rotates the hash on change)
-    // the optimizer would otherwise log an upstream 404 on every render.
+    // Skip Next.js image optimization for OAuth provider URLs. When a
+    // cached avatar goes stale (Discord rotates the hash on change) the
+    // optimizer would otherwise log an upstream 404 on every render.
     // Bypassing it lets the browser try directly and fail silently into
     // the icon fallback below until the next OAuth login refreshes the URL.
-    const isRemote = resolved.startsWith('http')
+    // Check the raw prop, not `resolved` — `resolved` for a local upload
+    // already has the API origin prepended in non-same-origin deployments.
+    const isRemote = avatarUrl?.startsWith('http') ?? false
     return (
       <Image
         src={resolved}


### PR DESCRIPTION
Prod was logging an upstream 404 on every render for users whose cached Discord avatar URL had gone stale — the in-memory failed-URL state prevents the broken <img> from being shown to the user, but the optimizer still proxied the URL on each fresh render before onError fired. Set unoptimized for any URL starting with http so the browser fetches it directly and the server stays quiet. Local /uploads paths stay optimized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user avatar loading for third-party authentication providers to reduce unnecessary error logs and enhance reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Turbootzz/Nimbus/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->