### PR TITLE
fix(api): reject non-UUID :id path params at router and handler

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -193,30 +193,32 @@ func main() {
 	services.Get("/", serviceHandler.GetServices)
 	services.Put("/reorder", serviceHandler.ReorderServices)     // Must be before /:id routes
 	services.Get("/favicon", serviceHandler.FetchServiceFavicon) // Must be before /:id routes
-	services.Get("/:id", serviceHandler.GetService)
-	services.Put("/:id", serviceHandler.UpdateService)
-	services.Delete("/:id", serviceHandler.DeleteService)
-	services.Post("/:id/check", serviceHandler.CheckService)
-	services.Get("/:id/status-logs", metricsHandler.GetRecentStatusLogs)
+	// <guid> constraint rejects non-UUID :id at the router level (404)
+	// so reserved-word paths like /favicon never crash through to SQL.
+	services.Get("/:id<guid>", serviceHandler.GetService)
+	services.Put("/:id<guid>", serviceHandler.UpdateService)
+	services.Delete("/:id<guid>", serviceHandler.DeleteService)
+	services.Post("/:id<guid>/check", serviceHandler.CheckService)
+	services.Get("/:id<guid>/status-logs", metricsHandler.GetRecentStatusLogs)
 
 	// Group routes (all protected)
 	groups := v1.Group("/groups", middleware.AuthMiddleware(authService, userRepo))
 	groups.Post("/", groupHandler.CreateGroup)
 	groups.Get("/", groupHandler.GetGroups)
 	groups.Put("/reorder", groupHandler.ReorderGroups) // Must be before /:id routes
-	groups.Get("/:id", groupHandler.GetGroup)
-	groups.Put("/:id", groupHandler.UpdateGroup)
-	groups.Delete("/:id", groupHandler.DeleteGroup)
+	groups.Get("/:id<guid>", groupHandler.GetGroup)
+	groups.Put("/:id<guid>", groupHandler.UpdateGroup)
+	groups.Delete("/:id<guid>", groupHandler.DeleteGroup)
 
 	// Webhook routes (all protected)
 	webhooks := v1.Group("/webhooks", middleware.AuthMiddleware(authService, userRepo))
 	webhooks.Post("/", webhookHandler.CreateWebhook)
 	webhooks.Get("/", webhookHandler.GetWebhooks)
-	webhooks.Get("/:id", webhookHandler.GetWebhook)
-	webhooks.Put("/:id", webhookHandler.UpdateWebhook)
-	webhooks.Delete("/:id", webhookHandler.DeleteWebhook)
-	webhooks.Post("/:id/test", webhookHandler.TestWebhook)
-	webhooks.Get("/:id/logs", webhookHandler.GetWebhookLogs)
+	webhooks.Get("/:id<guid>", webhookHandler.GetWebhook)
+	webhooks.Put("/:id<guid>", webhookHandler.UpdateWebhook)
+	webhooks.Delete("/:id<guid>", webhookHandler.DeleteWebhook)
+	webhooks.Post("/:id<guid>/test", webhookHandler.TestWebhook)
+	webhooks.Get("/:id<guid>/logs", webhookHandler.GetWebhookLogs)
 
 	// Static file serving (public, but files are only accessible if you know the filename)
 	// IMPORTANT: This must be registered BEFORE the uploads group to avoid auth middleware
@@ -233,12 +235,12 @@ func main() {
 
 	// Metrics routes (protected)
 	metrics := v1.Group("/metrics", middleware.AuthMiddleware(authService, userRepo))
-	metrics.Get("/:id", metricsHandler.GetServiceMetrics)
+	metrics.Get("/:id<guid>", metricsHandler.GetServiceMetrics)
 
 	// Prometheus metrics endpoint (supports both JWT and API key authentication)
 	// Middleware is optional - handler checks for both JWT (from middleware) and API key
 	prometheus := v1.Group("/prometheus")
-	prometheus.Get("/metrics/user/:userID", middleware.OptionalAuthMiddleware(authService, userRepo), metricsHandler.GetUserPrometheusMetrics)
+	prometheus.Get("/metrics/user/:userID<guid>", middleware.OptionalAuthMiddleware(authService, userRepo), metricsHandler.GetUserPrometheusMetrics)
 
 	// User preferences routes (protected)
 	preferences := v1.Group("/users/me/preferences", middleware.AuthMiddleware(authService, userRepo))
@@ -255,8 +257,8 @@ func main() {
 	admin := v1.Group("/admin", middleware.AuthMiddleware(authService, userRepo), middleware.AdminOnly())
 	admin.Get("/users", adminHandler.GetAllUsers)
 	admin.Get("/users/stats", adminHandler.GetUserStats)
-	admin.Put("/users/:id/role", adminHandler.UpdateUserRole)
-	admin.Delete("/users/:id", adminHandler.DeleteUser)
+	admin.Put("/users/:id<guid>/role", adminHandler.UpdateUserRole)
+	admin.Delete("/users/:id<guid>", adminHandler.DeleteUser)
 	admin.Get("/settings", settingsHandler.GetSettings)
 	admin.Get("/settings/smtp/status", settingsHandler.GetSMTPStatus)
 	admin.Put("/settings/smtp", settingsHandler.UpdateSMTPSettings)
@@ -280,6 +282,14 @@ func main() {
 	// Start rate limit cache cleanup worker
 	rateLimitCleanup := workers.NewRateLimitCleanupWorker()
 	rateLimitCleanup.Start()
+
+	// Catch-all 404 handler — registered last so it only fires for paths no
+	// other route matched. Returns JSON so API clients can parse it uniformly;
+	// in particular this covers Fiber's <guid> constraint rejections, which
+	// would otherwise hit Fiber's default text/plain "Cannot GET …" body.
+	app.Use(func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Not found"})
+	})
 
 	// Setup graceful shutdown
 	sigChan := make(chan os.Signal, 1)

--- a/backend/internal/handlers/admin_handler.go
+++ b/backend/internal/handlers/admin_handler.go
@@ -92,11 +92,9 @@ func (h *AdminHandler) GetUserStats(c *fiber.Ctx) error {
 
 // UpdateUserRole updates a user's role (admin only)
 func (h *AdminHandler) UpdateUserRole(c *fiber.Ctx) error {
-	userID := c.Params("id")
-	if userID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "User ID is required",
-		})
+	userID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Parse request body
@@ -148,11 +146,9 @@ func (h *AdminHandler) UpdateUserRole(c *fiber.Ctx) error {
 
 // DeleteUser deletes a user (admin only)
 func (h *AdminHandler) DeleteUser(c *fiber.Ctx) error {
-	userID := c.Params("id")
-	if userID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "User ID is required",
-		})
+	userID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Prevent admin from deleting themselves

--- a/backend/internal/handlers/admin_handler_test.go
+++ b/backend/internal/handlers/admin_handler_test.go
@@ -306,7 +306,7 @@ func TestAdminHandler_DeleteUser(t *testing.T) {
 		},
 		{
 			name:           "Delete non-existent user",
-			userID:         "non-existent-id",
+			userID:         "99999999-9999-9999-9999-999999999999",
 			currentUserID:  admin.ID,
 			expectedStatus: fiber.StatusNotFound,
 		},

--- a/backend/internal/handlers/group_handler.go
+++ b/backend/internal/handlers/group_handler.go
@@ -121,11 +121,9 @@ func (h *GroupHandler) GetGroup(c *fiber.Ctx) error {
 		return err
 	}
 
-	groupID := c.Params("id")
-	if groupID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Group ID is required",
-		})
+	groupID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	group, err := h.groupRepo.GetByID(c.Context(), groupID)
@@ -156,11 +154,9 @@ func (h *GroupHandler) UpdateGroup(c *fiber.Ctx) error {
 		return err
 	}
 
-	groupID := c.Params("id")
-	if groupID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Group ID is required",
-		})
+	groupID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	var req models.GroupUpdateRequest
@@ -233,11 +229,9 @@ func (h *GroupHandler) DeleteGroup(c *fiber.Ctx) error {
 		return err
 	}
 
-	groupID := c.Params("id")
-	if groupID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Group ID is required",
-		})
+	groupID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Check if services should be deleted with the group

--- a/backend/internal/handlers/group_handler_test.go
+++ b/backend/internal/handlers/group_handler_test.go
@@ -94,7 +94,7 @@ func TestGroupHandler_CreateGroup(t *testing.T) {
 	}{
 		{
 			name:   "Missing name",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupCreateRequest{
 				Color: "#ff0000",
 			},
@@ -103,7 +103,7 @@ func TestGroupHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name:   "Invalid color format",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupCreateRequest{
 				Name:  "Test Group",
 				Color: "invalid",
@@ -113,7 +113,7 @@ func TestGroupHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name:   "Name too long",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupCreateRequest{
 				Name:  string(make([]byte, 36)),
 				Color: "#ff0000",
@@ -185,8 +185,8 @@ func TestGroupHandler_GetGroups(t *testing.T) {
 
 	// Create test groups for user-1
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-1",
-		UserID:    "user-1",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Group 1",
 		Color:     "#ff0000",
 		Position:  0,
@@ -196,8 +196,8 @@ func TestGroupHandler_GetGroups(t *testing.T) {
 	})
 
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-2",
-		UserID:    "user-1",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Group 2",
 		Color:     "#00ff00",
 		Position:  1,
@@ -208,8 +208,8 @@ func TestGroupHandler_GetGroups(t *testing.T) {
 
 	// Create group for different user
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-3",
-		UserID:    "user-2",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:      "Group 3",
 		Color:     "#0000ff",
 		Position:  0,
@@ -220,7 +220,7 @@ func TestGroupHandler_GetGroups(t *testing.T) {
 
 	app := fiber.New()
 	app.Get("/groups", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.GetGroups(c)
 	})
 
@@ -247,7 +247,7 @@ func TestGroupHandler_GetGroups(t *testing.T) {
 
 	// Verify user isolation
 	for _, g := range groups {
-		if g.ID == "group-3" {
+		if g.ID == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3" {
 			t.Error("GetGroups returned another user's group")
 		}
 	}
@@ -262,8 +262,8 @@ func TestGroupHandler_GetGroup(t *testing.T) {
 
 	// Create test groups
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-1",
-		UserID:    "user-1",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Group 1",
 		Color:     "#ff0000",
 		Position:  0,
@@ -273,8 +273,8 @@ func TestGroupHandler_GetGroup(t *testing.T) {
 	})
 
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-2",
-		UserID:    "user-2",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:      "Group 2",
 		Color:     "#00ff00",
 		Position:  0,
@@ -291,20 +291,20 @@ func TestGroupHandler_GetGroup(t *testing.T) {
 	}{
 		{
 			name:           "Get own group",
-			userID:         "user-1",
-			groupID:        "group-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Get another user's group",
-			userID:         "user-1",
-			groupID:        "group-2",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
 			expectedStatus: http.StatusForbidden,
 		},
 		{
 			name:           "Get non-existent group",
-			userID:         "user-1",
-			groupID:        "non-existent",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "99999999-9999-9999-9999-999999999999",
 			expectedStatus: http.StatusNotFound,
 		},
 	}
@@ -339,8 +339,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 
 	// Create test groups
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-1",
-		UserID:    "user-1",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Group 1",
 		Color:     "#ff0000",
 		Position:  0,
@@ -350,8 +350,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 	})
 
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-2",
-		UserID:    "user-2",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:      "Group 2",
 		Color:     "#00ff00",
 		Position:  0,
@@ -370,8 +370,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 	}{
 		{
 			name:    "Successfully update group",
-			userID:  "user-1",
-			groupID: "group-1",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			requestBody: models.GroupUpdateRequest{
 				Name:  "Updated Name",
 				Color: "#00ff00",
@@ -381,8 +381,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name:    "Update only name",
-			userID:  "user-1",
-			groupID: "group-1",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			requestBody: models.GroupUpdateRequest{
 				Name: "Another Name",
 			},
@@ -391,8 +391,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name:    "Update only color",
-			userID:  "user-1",
-			groupID: "group-1",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			requestBody: models.GroupUpdateRequest{
 				Color: "#0000ff",
 			},
@@ -401,8 +401,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name:    "Invalid color format",
-			userID:  "user-1",
-			groupID: "group-1",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			requestBody: models.GroupUpdateRequest{
 				Color: "not-a-color",
 			},
@@ -411,8 +411,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name:    "Name too long",
-			userID:  "user-1",
-			groupID: "group-1",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			requestBody: models.GroupUpdateRequest{
 				Name: string(make([]byte, 36)), // 36 chars exceeds MaxGroupNameLen (35)
 			},
@@ -421,8 +421,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name:    "Update another user's group",
-			userID:  "user-1",
-			groupID: "group-2",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
 			requestBody: models.GroupUpdateRequest{
 				Name: "Hacked",
 			},
@@ -431,8 +431,8 @@ func TestGroupHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name:    "Update non-existent group",
-			userID:  "user-1",
-			groupID: "non-existent",
+			userID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID: "99999999-9999-9999-9999-999999999999",
 			requestBody: models.GroupUpdateRequest{
 				Name: "Updated",
 			},
@@ -488,8 +488,8 @@ func TestGroupHandler_DeleteGroup(t *testing.T) {
 
 	// Create test groups
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-1",
-		UserID:    "user-1",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Regular Group",
 		Color:     "#ff0000",
 		Position:  1,
@@ -499,8 +499,8 @@ func TestGroupHandler_DeleteGroup(t *testing.T) {
 	})
 
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-2",
-		UserID:    "user-1",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Default Group",
 		Color:     "#6366f1",
 		Position:  0,
@@ -510,8 +510,8 @@ func TestGroupHandler_DeleteGroup(t *testing.T) {
 	})
 
 	createGroupDirectly(t, db, &models.Group{
-		ID:        "group-3",
-		UserID:    "user-2",
+		ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:      "Other User Group",
 		Color:     "#0000ff",
 		Position:  0,
@@ -528,26 +528,26 @@ func TestGroupHandler_DeleteGroup(t *testing.T) {
 	}{
 		{
 			name:           "Delete regular group",
-			userID:         "user-1",
-			groupID:        "group-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Delete default group (should fail)",
-			userID:         "user-1",
-			groupID:        "group-2",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
 			expectedStatus: http.StatusForbidden,
 		},
 		{
 			name:           "Delete another user's group",
-			userID:         "user-1",
-			groupID:        "group-3",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
 			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name:           "Delete non-existent group",
-			userID:         "user-1",
-			groupID:        "non-existent",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "99999999-9999-9999-9999-999999999999",
 			expectedStatus: http.StatusNotFound,
 		},
 	}
@@ -583,8 +583,8 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 	// Create test groups
 	groups := []*models.Group{
 		{
-			ID:        "group-1",
-			UserID:    "user-1",
+			ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			Name:      "Group 1",
 			Color:     "#ff0000",
 			Position:  0,
@@ -593,8 +593,8 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 			UpdatedAt: time.Now(),
 		},
 		{
-			ID:        "group-2",
-			UserID:    "user-1",
+			ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			Name:      "Group 2",
 			Color:     "#00ff00",
 			Position:  1,
@@ -603,8 +603,8 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 			UpdatedAt: time.Now(),
 		},
 		{
-			ID:        "group-3",
-			UserID:    "user-2",
+			ID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 			Name:      "Group 3",
 			Color:     "#0000ff",
 			Position:  0,
@@ -627,11 +627,11 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 	}{
 		{
 			name:   "Successfully reorder groups",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
-					{ID: "group-1", Position: 1},
-					{ID: "group-2", Position: 0},
+					{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", Position: 1},
+					{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", Position: 0},
 				},
 			},
 			expectedStatus: http.StatusOK,
@@ -639,10 +639,10 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Reorder single group",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
-					{ID: "group-1", Position: 1}, // Valid position within bounds (user-1 has 2 groups)
+					{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", Position: 1}, // Valid position within bounds (user-1 has 2 groups)
 				},
 			},
 			expectedStatus: http.StatusOK,
@@ -650,10 +650,10 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Attempt to reorder another user's group",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
-					{ID: "group-3", Position: 0}, // Valid position, but wrong user
+					{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3", Position: 0}, // Valid position, but wrong user
 				},
 			},
 			expectedStatus: http.StatusNotFound,
@@ -661,10 +661,10 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Position out of bounds",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
-					{ID: "group-1", Position: 10}, // Invalid: user-1 only has 2 groups (positions 0-1)
+					{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", Position: 10}, // Invalid: user-1 only has 2 groups (positions 0-1)
 				},
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -672,7 +672,7 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Empty group ID",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
 					{ID: "", Position: 0},
@@ -683,10 +683,10 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Negative position",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
-					{ID: "group-1", Position: -1},
+					{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", Position: -1},
 				},
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -694,7 +694,7 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Empty groups array",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{},
 			},
@@ -703,10 +703,10 @@ func TestGroupHandler_ReorderGroups(t *testing.T) {
 		},
 		{
 			name:   "Non-existent group",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.GroupReorderRequest{
 				Groups: []models.GroupPosition{
-					{ID: "non-existent", Position: 0},
+					{ID: "99999999-9999-9999-9999-999999999999", Position: 0},
 				},
 			},
 			expectedStatus: http.StatusNotFound,
@@ -764,7 +764,7 @@ func TestGroupHandler_ReorderGroups_NoAuth(t *testing.T) {
 
 	requestBody := models.GroupReorderRequest{
 		Groups: []models.GroupPosition{
-			{ID: "group-1", Position: 0},
+			{ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", Position: 0},
 		},
 	}
 
@@ -791,7 +791,7 @@ func TestGroupHandler_ReorderGroups_InvalidJSON(t *testing.T) {
 
 	app := fiber.New()
 	app.Put("/groups/reorder", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.ReorderGroups(c)
 	})
 

--- a/backend/internal/handlers/helpers.go
+++ b/backend/internal/handlers/helpers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 )
 
 // RequireUserID extracts the user ID from context. If not found, it returns
@@ -12,4 +13,21 @@ func RequireUserID(c *fiber.Ctx) (string, error) {
 		return "", fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
 	}
 	return userID, nil
+}
+
+// RequireUUIDParam reads a route param and validates it parses as a UUID.
+// Returns a fiber.Error with 404 if invalid so non-UUID strings stay out of
+// SQL — Postgres would otherwise log "invalid input syntax for type uuid"
+// and the client would see a 500. Use for any :id-style path param.
+//
+// Empty -> 400; non-UUID -> 404; valid UUID (any case) -> returned as-is.
+func RequireUUIDParam(c *fiber.Ctx, key string) (string, error) {
+	v := c.Params(key)
+	if v == "" {
+		return "", fiber.NewError(fiber.StatusBadRequest, key+" is required")
+	}
+	if _, err := uuid.Parse(v); err != nil {
+		return "", fiber.NewError(fiber.StatusNotFound, "Not found")
+	}
+	return v, nil
 }

--- a/backend/internal/handlers/helpers_test.go
+++ b/backend/internal/handlers/helpers_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
@@ -103,5 +106,270 @@ func TestRequireUserID_WrongType(t *testing.T) {
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("Expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+// TestRequireUUIDParam mounts the helper on a route with NO <guid> constraint
+// so we exercise the in-handler path explicitly (constraint-less defense).
+func TestRequireUUIDParam(t *testing.T) {
+	app := fiber.New()
+	app.Get("/test/:id", func(c *fiber.Ctx) error {
+		id, err := RequireUUIDParam(c, "id")
+		if err != nil {
+			return err
+		}
+		return c.JSON(fiber.Map{"id": id})
+	})
+
+	cases := []struct {
+		name           string
+		id             string
+		expectedStatus int
+		expectedID     string // empty = don't check body
+	}{
+		{"valid lowercase UUID", "11111111-1111-1111-1111-111111111111", http.StatusOK, "11111111-1111-1111-1111-111111111111"},
+		{"valid uppercase UUID", "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", http.StatusOK, "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"},
+		{"valid mixed-case UUID", "AbCdEf01-2345-6789-aBcD-eF0123456789", http.StatusOK, "AbCdEf01-2345-6789-aBcD-eF0123456789"},
+		{"non-UUID word", "favicon", http.StatusNotFound, ""},
+		{"non-UUID garbage", "not-a-uuid-12345", http.StatusNotFound, ""},
+		// URL-encoded SQL injection payload — even after Fiber decodes it,
+		// it's not a valid UUID, so the helper rejects with 404.
+		{"SQL injection (encoded)", "1%27%3B%20DROP%20TABLE%20services", http.StatusNotFound, ""},
+		{"too short", "1234", http.StatusNotFound, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test/"+tc.id, nil)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("Failed to test request: %v", err)
+			}
+			if resp.StatusCode != tc.expectedStatus {
+				t.Errorf("Expected status %d, got %d (id=%q)", tc.expectedStatus, resp.StatusCode, tc.id)
+			}
+			if tc.expectedID != "" {
+				var body map[string]string
+				if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+					t.Fatalf("Failed to decode response: %v", err)
+				}
+				if body["id"] != tc.expectedID {
+					t.Errorf("Expected id %q, got %q", tc.expectedID, body["id"])
+				}
+			}
+		})
+	}
+}
+
+// TestRouteGuidConstraintRejectsNonUUID is the regression guard for the bug
+// that caused production Postgres `invalid input syntax for type uuid` errors
+// when /services/favicon hit the old backend (no /favicon route) and matched
+// /:id with id="favicon". It also confirms that a static reserved-word route
+// registered alongside `:id<guid>` still wins, so paths like /services/favicon
+// don't get swallowed by the constraint.
+func TestRouteGuidConstraintRejectsNonUUID(t *testing.T) {
+	app := fiber.New()
+	handlerCalled := false
+	app.Get("/services/favicon", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+	app.Get("/services/:id<guid>", func(c *fiber.Ctx) error {
+		handlerCalled = true
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	// Static route still wins for the reserved word.
+	req := httptest.NewRequest(http.MethodGet, "/services/favicon", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/services/favicon should hit the static route, got %d", resp.StatusCode)
+	}
+	if handlerCalled {
+		t.Error("the /:id handler should not have been called for /favicon")
+	}
+
+	// Non-UUID :id is rejected by the router, NOT passed to the handler.
+	req = httptest.NewRequest(http.MethodGet, "/services/not-a-uuid", nil)
+	resp, err = app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("non-UUID :id should return 404 from the router, got %d", resp.StatusCode)
+	}
+	if handlerCalled {
+		t.Error("router constraint should have rejected the non-UUID before reaching the handler")
+	}
+
+	// Valid UUID :id reaches the handler.
+	handlerCalled = false
+	req = httptest.NewRequest(http.MethodGet, "/services/11111111-1111-1111-1111-111111111111", nil)
+	resp, err = app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("valid UUID :id should reach the handler, got %d", resp.StatusCode)
+	}
+	if !handlerCalled {
+		t.Error("valid UUID :id should reach the handler")
+	}
+}
+
+// TestRouteGuidConstraintCoversAllResourceGroups confirms that every resource
+// group under /api/v1 that takes a UUID :id has the <guid> constraint in
+// place — if a future contributor drops the constraint on any of them, this
+// test catches it. Each row exercises a single route shape and expects 404
+// at the router (handler never runs) for a non-UUID path.
+func TestRouteGuidConstraintCoversAllResourceGroups(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		routeSpec  string // pattern registered with Fiber
+		requestURL string // the actual path requested (non-UUID)
+	}{
+		{"services :id", http.MethodGet, "/api/v1/services/:id<guid>", "/api/v1/services/not-a-uuid"},
+		{"services :id/check", http.MethodPost, "/api/v1/services/:id<guid>/check", "/api/v1/services/bad-id/check"},
+		{"services :id/status-logs", http.MethodGet, "/api/v1/services/:id<guid>/status-logs", "/api/v1/services/bad-id/status-logs"},
+		{"groups :id", http.MethodGet, "/api/v1/groups/:id<guid>", "/api/v1/groups/not-a-uuid"},
+		{"webhooks :id", http.MethodGet, "/api/v1/webhooks/:id<guid>", "/api/v1/webhooks/not-a-uuid"},
+		{"webhooks :id/test", http.MethodPost, "/api/v1/webhooks/:id<guid>/test", "/api/v1/webhooks/bad-id/test"},
+		{"webhooks :id/logs", http.MethodGet, "/api/v1/webhooks/:id<guid>/logs", "/api/v1/webhooks/bad-id/logs"},
+		{"metrics :id", http.MethodGet, "/api/v1/metrics/:id<guid>", "/api/v1/metrics/not-a-uuid"},
+		{"prometheus :userID", http.MethodGet, "/api/v1/prometheus/metrics/user/:userID<guid>", "/api/v1/prometheus/metrics/user/not-a-uuid"},
+		{"admin :id/role", http.MethodPut, "/api/v1/admin/users/:id<guid>/role", "/api/v1/admin/users/bad-id/role"},
+		{"admin :id", http.MethodDelete, "/api/v1/admin/users/:id<guid>", "/api/v1/admin/users/bad-id"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			handlerCalled := false
+			app.Add(tc.method, tc.routeSpec, func(c *fiber.Ctx) error {
+				handlerCalled = true
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			req := httptest.NewRequest(tc.method, tc.requestURL, nil)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("Failed to test request: %v", err)
+			}
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("Expected 404 from router for non-UUID, got %d", resp.StatusCode)
+			}
+			if handlerCalled {
+				t.Errorf("Router should have rejected %s before reaching handler", tc.requestURL)
+			}
+		})
+	}
+}
+
+// TestCatchAll404ReturnsJSON proves that a Fiber app with the catch-all
+// middleware from main.go responds with JSON for unmatched paths — including
+// paths rejected by the <guid> constraint. The frontend's API client expects
+// JSON for every response; without this catch-all the constraint rejection
+// falls back to Fiber's default "text/plain Cannot GET …" body and the
+// frontend renders a generic "API returned an invalid response" toast.
+func TestCatchAll404ReturnsJSON(t *testing.T) {
+	app := fiber.New()
+	app.Get("/services/:id<guid>", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+	// Mirror main.go's catch-all (must be registered last).
+	app.Use(func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Not found"})
+	})
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"constraint-rejected non-UUID", "/services/not-a-uuid"},
+		{"totally unknown path", "/no-such/endpoint/anywhere"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("app.Test failed: %v", err)
+			}
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("Expected 404, got %d", resp.StatusCode)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+				t.Errorf("Expected Content-Type to contain application/json, got %q", ct)
+			}
+			var body map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("Failed to decode JSON body: %v", err)
+			}
+			if body["error"] != "Not found" {
+				t.Errorf("Expected error=\"Not found\", got %q", body["error"])
+			}
+		})
+	}
+}
+
+// TestMainGoRoutesHaveGuidConstraint statically inspects the production route
+// table in backend/cmd/server/main.go to confirm every UUID-typed param (`:id`
+// and `:userID`) carries the `<guid>` constraint. The companion test above
+// (TestRouteGuidConstraintCoversAllResourceGroups) only proves Fiber's
+// constraint *behaviour* — it can't catch a contributor dropping `<guid>` from
+// a real registration. This test reads the actual main.go source so the
+// failure mode for #152 is caught at the source level.
+func TestMainGoRoutesHaveGuidConstraint(t *testing.T) {
+	const mainGoPath = "../../cmd/server/main.go"
+	src, err := os.ReadFile(mainGoPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainGoPath, err)
+	}
+
+	// Match Fiber registrations of the form `.METHOD("/path/...", ...)` where
+	// the path is the first argument.
+	routeRE := regexp.MustCompile(`\.(?:Get|Post|Put|Delete|Patch)\("([^"]+)"`)
+	// Match Fiber's generic `.Add(method, "/path", ...)` form where the path
+	// is the SECOND argument. The method arg can be a constant (http.MethodGet)
+	// or a string literal — either way we just need to skip past it.
+	addRouteRE := regexp.MustCompile(`\.Add\([^,]+,\s*"([^"]+)"`)
+	// Within a registered path, find every `:name` optionally followed by a
+	// `<constraint>` block. Whitelist the param names we know must be UUIDs.
+	paramRE := regexp.MustCompile(`:([a-zA-Z_]+)(<[^>]*>)?`)
+
+	uuidParams := map[string]bool{
+		"id":     true,
+		"userID": true,
+	}
+
+	matches := routeRE.FindAllStringSubmatch(string(src), -1)
+	matches = append(matches, addRouteRE.FindAllStringSubmatch(string(src), -1)...)
+	if len(matches) == 0 {
+		t.Fatal("no route registrations matched in main.go - test regex is broken")
+	}
+
+	uuidParamCount := 0
+	for _, m := range matches {
+		path := m[1]
+		for _, p := range paramRE.FindAllStringSubmatch(path, -1) {
+			name, constraint := p[1], p[2]
+			if !uuidParams[name] {
+				continue
+			}
+			uuidParamCount++
+			if constraint != "<guid>" {
+				if constraint == "" {
+					t.Errorf("route %q: param :%s is missing the <guid> constraint", path, name)
+				} else {
+					t.Errorf("route %q: param :%s has constraint %q, want <guid>", path, name, constraint)
+				}
+			}
+		}
+	}
+	if uuidParamCount == 0 {
+		t.Fatal("no :id or :userID params found in main.go - test regex is broken")
 	}
 }

--- a/backend/internal/handlers/metrics_handler.go
+++ b/backend/internal/handlers/metrics_handler.go
@@ -25,9 +25,9 @@ func NewMetricsHandler(metricsService *services.MetricsService, serviceRepo repo
 // GetServiceMetrics retrieves metrics for a specific service
 // GET /api/v1/metrics/:serviceID
 func (h *MetricsHandler) GetServiceMetrics(c *fiber.Ctx) error {
-	serviceID := c.Params("id")
-	if serviceID == "" {
-		return BadRequest(c, "Service ID is required")
+	serviceID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Get authenticated user
@@ -86,9 +86,9 @@ func (h *MetricsHandler) GetServiceMetrics(c *fiber.Ctx) error {
 // GetRecentStatusLogs retrieves recent status logs for a service
 // GET /api/v1/services/:id/status-logs
 func (h *MetricsHandler) GetRecentStatusLogs(c *fiber.Ctx) error {
-	serviceID := c.Params("id")
-	if serviceID == "" {
-		return BadRequest(c, "Service ID is required")
+	serviceID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Get authenticated user
@@ -151,10 +151,10 @@ func (h *MetricsHandler) GetPrometheusMetrics(c *fiber.Ctx) error {
 // GetUserPrometheusMetrics exports metrics for a specific user (authenticated via JWT or API key)
 // GET /api/v1/prometheus/metrics/user/:userID
 func (h *MetricsHandler) GetUserPrometheusMetrics(c *fiber.Ctx) error {
-	// Get requested user ID from URL and validate
-	requestedUserID := c.Params("userID")
-	if requestedUserID == "" {
-		return c.Status(fiber.StatusBadRequest).SendString("# User ID required\n")
+	// Get and validate requested user ID from URL (UUID-only).
+	requestedUserID, err := RequireUUIDParam(c, "userID")
+	if err != nil {
+		return err
 	}
 
 	// Try JWT authentication first (from middleware)

--- a/backend/internal/handlers/metrics_handler_test.go
+++ b/backend/internal/handlers/metrics_handler_test.go
@@ -143,8 +143,8 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 	// Create test services for user-1
 	responseTime := 100
 	createTestService(t, db, &models.Service{
-		ID:                "service-1",
-		UserID:            "user-1",
+		ID:                "11111111-1111-1111-1111-111111111111",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:              "Test Service 1",
 		URL:               "https://example1.com",
 		Icon:              "🔗",
@@ -157,8 +157,8 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 	})
 
 	createTestService(t, db, &models.Service{
-		ID:                "service-2",
-		UserID:            "user-1",
+		ID:                "22222222-2222-2222-2222-222222222222",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:              "Test Service 2",
 		URL:               "https://example2.com",
 		Icon:              "🔗",
@@ -171,8 +171,8 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 
 	// Create test service for user-2 (should not appear in user-1's metrics)
 	createTestService(t, db, &models.Service{
-		ID:                "service-3",
-		UserID:            "user-2",
+		ID:                "33333333-3333-3333-3333-333333333333",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:              "User 2 Service",
 		URL:               "https://example3.com",
 		Icon:              "🔗",
@@ -195,7 +195,7 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 	}{
 		{
 			name:           "Valid API key - should return user's metrics",
-			userID:         "user-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			apiKey:         testAPIKey,
 			expectedStatus: 200,
 			checkBody: func(t *testing.T, body string) {
@@ -221,7 +221,7 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 		},
 		{
 			name:           "Invalid API key - should return 401",
-			userID:         "user-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			apiKey:         "wrong-api-key",
 			expectedStatus: 401,
 			checkBody: func(t *testing.T, body string) {
@@ -232,7 +232,7 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 		},
 		{
 			name:           "Missing API key - should return 401",
-			userID:         "user-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			apiKey:         "",
 			expectedStatus: 401,
 			checkBody: func(t *testing.T, body string) {
@@ -243,7 +243,7 @@ func TestGetUserPrometheusMetrics_WithAPIKey(t *testing.T) {
 		},
 		{
 			name:           "Valid API key for different user - should return their metrics",
-			userID:         "user-2",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 			apiKey:         testAPIKey,
 			expectedStatus: 200,
 			checkBody: func(t *testing.T, body string) {
@@ -304,8 +304,8 @@ func TestGetUserPrometheusMetrics_WithXAPIKeyHeader(t *testing.T) {
 
 	// Create test service
 	createTestService(t, db, &models.Service{
-		ID:                "service-1",
-		UserID:            "user-1",
+		ID:                "11111111-1111-1111-1111-111111111111",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:              "Test Service",
 		URL:               "https://example.com",
 		Icon:              "🔗",
@@ -320,7 +320,7 @@ func TestGetUserPrometheusMetrics_WithXAPIKeyHeader(t *testing.T) {
 	app.Get("/api/v1/prometheus/metrics/user/:userID", handler.GetUserPrometheusMetrics)
 
 	// Test with X-API-Key header
-	req := httptest.NewRequest("GET", "/api/v1/prometheus/metrics/user/user-1", nil)
+	req := httptest.NewRequest("GET", "/api/v1/prometheus/metrics/user/cccccccc-cccc-cccc-cccc-ccccccccccc1", nil)
 	req.Header.Set("X-API-Key", testAPIKey)
 
 	resp, err := app.Test(req)
@@ -358,8 +358,8 @@ func TestGetUserPrometheusMetrics_WithJWTAuthentication(t *testing.T) {
 
 	// Create test services
 	createTestService(t, db, &models.Service{
-		ID:                "service-1",
-		UserID:            "user-1",
+		ID:                "11111111-1111-1111-1111-111111111111",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:              "User 1 Service",
 		URL:               "https://example1.com",
 		Icon:              "🔗",
@@ -371,8 +371,8 @@ func TestGetUserPrometheusMetrics_WithJWTAuthentication(t *testing.T) {
 	})
 
 	createTestService(t, db, &models.Service{
-		ID:                "service-2",
-		UserID:            "user-2",
+		ID:                "22222222-2222-2222-2222-222222222222",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:              "User 2 Service",
 		URL:               "https://example2.com",
 		Icon:              "🔗",
@@ -388,7 +388,7 @@ func TestGetUserPrometheusMetrics_WithJWTAuthentication(t *testing.T) {
 	// Middleware to simulate JWT authentication
 	app.Use(func(c *fiber.Ctx) error {
 		// Simulate authenticated user (would normally come from JWT)
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		c.Locals("role", "user")
 		return c.Next()
 	})
@@ -403,13 +403,13 @@ func TestGetUserPrometheusMetrics_WithJWTAuthentication(t *testing.T) {
 	}{
 		{
 			name:           "User accessing their own metrics - should succeed",
-			requestUserID:  "user-1",
+			requestUserID:  "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			expectedStatus: 200,
 			expectService:  "User 1 Service",
 		},
 		{
 			name:           "User accessing another user's metrics - should be forbidden",
-			requestUserID:  "user-2",
+			requestUserID:  "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 			expectedStatus: 403,
 			expectService:  "",
 		},
@@ -453,8 +453,8 @@ func TestGetUserPrometheusMetrics_AdminAccess(t *testing.T) {
 
 	// Create test service for user-2
 	createTestService(t, db, &models.Service{
-		ID:                "service-1",
-		UserID:            "user-2",
+		ID:                "11111111-1111-1111-1111-111111111111",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:              "User 2 Service",
 		URL:               "https://example.com",
 		Icon:              "🔗",
@@ -477,7 +477,7 @@ func TestGetUserPrometheusMetrics_AdminAccess(t *testing.T) {
 	app.Get("/api/v1/prometheus/metrics/user/:userID", handler.GetUserPrometheusMetrics)
 
 	// Admin should be able to access any user's metrics
-	req := httptest.NewRequest("GET", "/api/v1/prometheus/metrics/user/user-2", nil)
+	req := httptest.NewRequest("GET", "/api/v1/prometheus/metrics/user/cccccccc-cccc-cccc-cccc-ccccccccccc2", nil)
 
 	resp, err := app.Test(req)
 	if err != nil {
@@ -516,7 +516,7 @@ func TestGetUserPrometheusMetrics_EmptyServices(t *testing.T) {
 	app.Get("/api/v1/prometheus/metrics/user/:userID", handler.GetUserPrometheusMetrics)
 
 	// Request metrics for user with no services
-	req := httptest.NewRequest("GET", "/api/v1/prometheus/metrics/user/user-no-services", nil)
+	req := httptest.NewRequest("GET", "/api/v1/prometheus/metrics/user/dddddddd-dddd-dddd-dddd-dddddddddddd", nil)
 	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 
 	resp, err := app.Test(req)

--- a/backend/internal/handlers/service_handler.go
+++ b/backend/internal/handlers/service_handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/nimbus/backend/internal/models"
 	"github.com/nimbus/backend/internal/repository"
 	"github.com/nimbus/backend/internal/services"
@@ -37,6 +38,14 @@ func (h *ServiceHandler) validateGroupOwnership(c *fiber.Ctx, groupID, userID st
 	if h.groupRepo == nil {
 		c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Group validation unavailable",
+		})
+		return false
+	}
+	// Reject non-UUID group_id from the request body before it reaches SQL,
+	// so Postgres doesn't log "invalid input syntax for type uuid".
+	if _, err := uuid.Parse(groupID); err != nil {
+		c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid group_id: must be a UUID",
 		})
 		return false
 	}
@@ -223,12 +232,10 @@ func (h *ServiceHandler) GetService(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Get service ID from URL params
-	serviceID := c.Params("id")
-	if serviceID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Service ID is required",
-		})
+	// Get and validate service ID from URL params (UUID-only).
+	serviceID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Get service from database
@@ -261,12 +268,10 @@ func (h *ServiceHandler) UpdateService(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Get service ID from URL params
-	serviceID := c.Params("id")
-	if serviceID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Service ID is required",
-		})
+	// Get and validate service ID from URL params (UUID-only).
+	serviceID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	var req models.ServiceUpdateRequest
@@ -431,12 +436,10 @@ func (h *ServiceHandler) DeleteService(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Get service ID from URL params
-	serviceID := c.Params("id")
-	if serviceID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Service ID is required",
-		})
+	// Get and validate service ID from URL params (UUID-only).
+	serviceID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Get existing service to check for uploaded images to clean up
@@ -495,12 +498,10 @@ func (h *ServiceHandler) CheckService(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Get service ID from URL params
-	serviceID := c.Params("id")
-	if serviceID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Service ID is required",
-		})
+	// Get and validate service ID from URL params (UUID-only).
+	serviceID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Get service from database
@@ -580,6 +581,12 @@ func (h *ServiceHandler) ReorderServices(c *fiber.Ctx) error {
 		if sp.ID == "" {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"error": "Service ID cannot be empty",
+			})
+		}
+		// Reject non-UUID service IDs before they reach SQL.
+		if _, err := uuid.Parse(sp.ID); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "Service ID must be a UUID",
 			})
 		}
 		if sp.Position < 0 {

--- a/backend/internal/handlers/service_handler_test.go
+++ b/backend/internal/handlers/service_handler_test.go
@@ -116,8 +116,8 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 	// Create test services
 	services := []*models.Service{
 		{
-			ID:        "service-1",
-			UserID:    "user-1",
+			ID:        "11111111-1111-1111-1111-111111111111",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			Name:      "Service 1",
 			URL:       "https://example1.com",
 			Icon:      "🔗",
@@ -127,8 +127,8 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 			UpdatedAt: time.Now(),
 		},
 		{
-			ID:        "service-2",
-			UserID:    "user-1",
+			ID:        "22222222-2222-2222-2222-222222222222",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			Name:      "Service 2",
 			URL:       "https://example2.com",
 			Icon:      "🔗",
@@ -138,8 +138,8 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 			UpdatedAt: time.Now(),
 		},
 		{
-			ID:        "service-3",
-			UserID:    "user-2",
+			ID:        "33333333-3333-3333-3333-333333333333",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 			Name:      "Service 3",
 			URL:       "https://example3.com",
 			Icon:      "🔗",
@@ -163,11 +163,11 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 	}{
 		{
 			name:   "Successfully reorder services",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{
-					{ID: "service-1", Position: 1},
-					{ID: "service-2", Position: 0},
+					{ID: "11111111-1111-1111-1111-111111111111", Position: 1},
+					{ID: "22222222-2222-2222-2222-222222222222", Position: 0},
 				},
 			},
 			expectedStatus: http.StatusOK,
@@ -175,10 +175,10 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 		},
 		{
 			name:   "Reorder single service",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{
-					{ID: "service-1", Position: 5},
+					{ID: "11111111-1111-1111-1111-111111111111", Position: 5},
 				},
 			},
 			expectedStatus: http.StatusOK,
@@ -186,10 +186,10 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 		},
 		{
 			name:   "Attempt to reorder another user's service",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{
-					{ID: "service-3", Position: 10},
+					{ID: "33333333-3333-3333-3333-333333333333", Position: 10},
 				},
 			},
 			expectedStatus: http.StatusNotFound,
@@ -197,7 +197,7 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 		},
 		{
 			name:   "Empty service ID",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{
 					{ID: "", Position: 0},
@@ -208,10 +208,10 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 		},
 		{
 			name:   "Negative position",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{
-					{ID: "service-1", Position: -1},
+					{ID: "11111111-1111-1111-1111-111111111111", Position: -1},
 				},
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -219,7 +219,7 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 		},
 		{
 			name:   "Empty services array",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{},
 			},
@@ -228,10 +228,11 @@ func TestServiceHandler_ReorderServices(t *testing.T) {
 		},
 		{
 			name:   "Non-existent service",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceReorderRequest{
 				Services: []models.ServicePosition{
-					{ID: "non-existent", Position: 0},
+					// Valid UUID format, but no service with this ID exists.
+					{ID: "99999999-9999-9999-9999-999999999999", Position: 0},
 				},
 			},
 			expectedStatus: http.StatusNotFound,
@@ -297,7 +298,7 @@ func TestServiceHandler_ReorderServices_NoAuth(t *testing.T) {
 
 	requestBody := models.ServiceReorderRequest{
 		Services: []models.ServicePosition{
-			{ID: "service-1", Position: 0},
+			{ID: "11111111-1111-1111-1111-111111111111", Position: 0},
 		},
 	}
 
@@ -325,7 +326,7 @@ func TestServiceHandler_ReorderServices_InvalidJSON(t *testing.T) {
 	app := fiber.New()
 
 	app.Put("/services/reorder", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.ReorderServices(c)
 	})
 
@@ -358,7 +359,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 	}{
 		{
 			name:   "Missing name",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceCreateRequest{
 				URL: "https://example.com",
 			},
@@ -367,7 +368,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 		},
 		{
 			name:   "Missing URL",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceCreateRequest{
 				Name: "Test Service",
 			},
@@ -376,7 +377,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 		},
 		{
 			name:   "Invalid URL format",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.ServiceCreateRequest{
 				Name: "Test Service",
 				URL:  "not-a-valid-url",
@@ -419,8 +420,8 @@ func TestServiceHandler_GetServices(t *testing.T) {
 
 	// Create test services for user-1
 	createServiceDirectly(t, db, &models.Service{
-		ID:        "service-1",
-		UserID:    "user-1",
+		ID:        "11111111-1111-1111-1111-111111111111",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Service 1",
 		URL:       "https://example1.com",
 		Icon:      "🔗",
@@ -430,8 +431,8 @@ func TestServiceHandler_GetServices(t *testing.T) {
 	})
 
 	createServiceDirectly(t, db, &models.Service{
-		ID:        "service-2",
-		UserID:    "user-1",
+		ID:        "22222222-2222-2222-2222-222222222222",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Service 2",
 		URL:       "https://example2.com",
 		Icon:      "🔗",
@@ -442,7 +443,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 
 	app := fiber.New()
 	app.Get("/services", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.GetServices(c)
 	})
 
@@ -465,8 +466,8 @@ func TestServiceHandler_DeleteService(t *testing.T) {
 	handler := NewServiceHandler(serviceRepo, nil, nil)
 
 	createServiceDirectly(t, db, &models.Service{
-		ID:        "service-1",
-		UserID:    "user-1",
+		ID:        "11111111-1111-1111-1111-111111111111",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Service 1",
 		URL:       "https://example1.com",
 		Icon:      "🔗",
@@ -483,14 +484,14 @@ func TestServiceHandler_DeleteService(t *testing.T) {
 	}{
 		{
 			name:           "Successfully delete service",
-			userID:         "user-1",
-			serviceID:      "service-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID:      "11111111-1111-1111-1111-111111111111",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Delete non-existent service",
-			userID:         "user-1",
-			serviceID:      "non-existent",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID:      "99999999-9999-9999-9999-999999999999",
 			expectedStatus: http.StatusNotFound,
 		},
 	}
@@ -525,8 +526,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 
 	// Create test service
 	createServiceDirectly(t, db, &models.Service{
-		ID:        "service-1",
-		UserID:    "user-1",
+		ID:        "11111111-1111-1111-1111-111111111111",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Service 1",
 		URL:       "https://example1.com",
 		Icon:      "🔗",
@@ -538,8 +539,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 
 	// Create service owned by different user
 	createServiceDirectly(t, db, &models.Service{
-		ID:        "service-2",
-		UserID:    "user-2",
+		ID:        "22222222-2222-2222-2222-222222222222",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:      "Service 2",
 		URL:       "https://example2.com",
 		Icon:      "🔗",
@@ -558,8 +559,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 	}{
 		{
 			name:      "Successfully update service with valid card_size",
-			userID:    "user-1",
-			serviceID: "service-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID: "11111111-1111-1111-1111-111111111111",
 			requestBody: models.ServiceUpdateRequest{
 				Name:     "Updated Service",
 				URL:      "https://updated.com",
@@ -570,8 +571,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 		},
 		{
 			name:      "Update service with 1x1 card size",
-			userID:    "user-1",
-			serviceID: "service-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID: "11111111-1111-1111-1111-111111111111",
 			requestBody: models.ServiceUpdateRequest{
 				Name:     "Updated Service",
 				URL:      "https://updated.com",
@@ -582,8 +583,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 		},
 		{
 			name:      "Update with invalid card_size",
-			userID:    "user-1",
-			serviceID: "service-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID: "11111111-1111-1111-1111-111111111111",
 			requestBody: models.ServiceUpdateRequest{
 				Name:     "Updated Service",
 				URL:      "https://updated.com",
@@ -594,8 +595,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 		},
 		{
 			name:      "Update preserves card_size when not provided",
-			userID:    "user-1",
-			serviceID: "service-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID: "11111111-1111-1111-1111-111111111111",
 			requestBody: models.ServiceUpdateRequest{
 				Name: "Updated Service",
 				URL:  "https://updated.com",
@@ -606,8 +607,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 		},
 		{
 			name:      "Attempt to update another user's service",
-			userID:    "user-1",
-			serviceID: "service-2",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID: "22222222-2222-2222-2222-222222222222",
 			requestBody: models.ServiceUpdateRequest{
 				Name:     "Updated Service",
 				URL:      "https://updated.com",
@@ -618,8 +619,8 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 		},
 		{
 			name:      "Update non-existent service",
-			userID:    "user-1",
-			serviceID: "non-existent",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID: "99999999-9999-9999-9999-999999999999",
 			requestBody: models.ServiceUpdateRequest{
 				Name: "Updated Service",
 				URL:  "https://updated.com",
@@ -704,8 +705,8 @@ func TestServiceHandler_CreateService_GroupValidation(t *testing.T) {
 
 	// Create a group for user-1
 	createGroupDirectly(t, db, &models.Group{
-		ID:                "group-1",
-		UserID:            "user-1",
+		ID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:              "User 1 Group",
 		Color:             "#3B82F6",
 		Position:          0,
@@ -716,8 +717,8 @@ func TestServiceHandler_CreateService_GroupValidation(t *testing.T) {
 
 	// Create a group for user-2
 	createGroupDirectly(t, db, &models.Group{
-		ID:                "group-2",
-		UserID:            "user-2",
+		ID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:              "User 2 Group",
 		Color:             "#3B82F6",
 		Position:          0,
@@ -737,14 +738,14 @@ func TestServiceHandler_CreateService_GroupValidation(t *testing.T) {
 	}{
 		{
 			name:           "Create service with non-existent group_id",
-			userID:         "user-1",
-			groupID:        "non-existent-group",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "88888888-8888-8888-8888-888888888888",
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "Create service with group_id belonging to another user",
-			userID:         "user-1",
-			groupID:        "group-2",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
 			expectedStatus: http.StatusForbidden,
 		},
 	}
@@ -789,8 +790,8 @@ func TestServiceHandler_UpdateService_GroupValidation(t *testing.T) {
 
 	// Create groups
 	createGroupDirectly(t, db, &models.Group{
-		ID:                "group-1",
-		UserID:            "user-1",
+		ID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:              "User 1 Group",
 		Color:             "#3B82F6",
 		Position:          0,
@@ -800,8 +801,8 @@ func TestServiceHandler_UpdateService_GroupValidation(t *testing.T) {
 	})
 
 	createGroupDirectly(t, db, &models.Group{
-		ID:                "group-2",
-		UserID:            "user-2",
+		ID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+		UserID:            "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:              "User 2 Group",
 		Color:             "#3B82F6",
 		Position:          0,
@@ -812,8 +813,8 @@ func TestServiceHandler_UpdateService_GroupValidation(t *testing.T) {
 
 	// Create test service
 	createServiceDirectly(t, db, &models.Service{
-		ID:        "service-1",
-		UserID:    "user-1",
+		ID:        "11111111-1111-1111-1111-111111111111",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Test Service",
 		URL:       "https://example.com",
 		Icon:      "🔗",
@@ -831,23 +832,23 @@ func TestServiceHandler_UpdateService_GroupValidation(t *testing.T) {
 	}{
 		{
 			name:           "Update service with valid group_id",
-			userID:         "user-1",
-			serviceID:      "service-1",
-			groupID:        "group-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID:      "11111111-1111-1111-1111-111111111111",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Update service with non-existent group_id",
-			userID:         "user-1",
-			serviceID:      "service-1",
-			groupID:        "non-existent-group",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID:      "11111111-1111-1111-1111-111111111111",
+			groupID:        "88888888-8888-8888-8888-888888888888",
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "Update service with group_id belonging to another user",
-			userID:         "user-1",
-			serviceID:      "service-1",
-			groupID:        "group-2",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			serviceID:      "11111111-1111-1111-1111-111111111111",
+			groupID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
 			expectedStatus: http.StatusForbidden,
 		},
 	}
@@ -892,7 +893,7 @@ func TestServiceHandler_CreateService_NilGroupRepo(t *testing.T) {
 
 	app := fiber.New()
 	app.Post("/services", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.CreateService(c)
 	})
 

--- a/backend/internal/handlers/webhook_handler.go
+++ b/backend/internal/handlers/webhook_handler.go
@@ -174,11 +174,9 @@ func (h *WebhookHandler) GetWebhook(c *fiber.Ctx) error {
 		return err
 	}
 
-	webhookID := c.Params("id")
-	if webhookID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Webhook ID is required",
-		})
+	webhookID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	webhook, err := h.webhookRepo.GetByID(c.Context(), webhookID, userID)
@@ -203,11 +201,9 @@ func (h *WebhookHandler) UpdateWebhook(c *fiber.Ctx) error {
 		return err
 	}
 
-	webhookID := c.Params("id")
-	if webhookID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Webhook ID is required",
-		})
+	webhookID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	var req models.WebhookUpdateRequest
@@ -308,11 +304,9 @@ func (h *WebhookHandler) DeleteWebhook(c *fiber.Ctx) error {
 		return err
 	}
 
-	webhookID := c.Params("id")
-	if webhookID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Webhook ID is required",
-		})
+	webhookID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	if err := h.webhookRepo.Delete(c.Context(), webhookID, userID); err != nil {
@@ -336,11 +330,9 @@ func (h *WebhookHandler) TestWebhook(c *fiber.Ctx) error {
 		return err
 	}
 
-	webhookID := c.Params("id")
-	if webhookID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Webhook ID is required",
-		})
+	webhookID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Verify webhook exists and belongs to user
@@ -393,11 +385,9 @@ func (h *WebhookHandler) GetWebhookLogs(c *fiber.Ctx) error {
 		return err
 	}
 
-	webhookID := c.Params("id")
-	if webhookID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Webhook ID is required",
-		})
+	webhookID, err := RequireUUIDParam(c, "id")
+	if err != nil {
+		return err
 	}
 
 	// Verify webhook exists and belongs to user

--- a/backend/internal/handlers/webhook_handler_test.go
+++ b/backend/internal/handlers/webhook_handler_test.go
@@ -118,7 +118,7 @@ func TestWebhookHandler_CreateWebhook(t *testing.T) {
 	}{
 		{
 			name:   "Successfully create webhook",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.WebhookCreateRequest{
 				Name:   "Test Webhook",
 				URL:    "https://discord.com/api/webhooks/123/abc",
@@ -129,7 +129,7 @@ func TestWebhookHandler_CreateWebhook(t *testing.T) {
 		},
 		{
 			name:   "Missing name",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.WebhookCreateRequest{
 				URL: "https://example.com/webhook",
 			},
@@ -138,7 +138,7 @@ func TestWebhookHandler_CreateWebhook(t *testing.T) {
 		},
 		{
 			name:   "Missing URL",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.WebhookCreateRequest{
 				Name: "Test Webhook",
 			},
@@ -147,7 +147,7 @@ func TestWebhookHandler_CreateWebhook(t *testing.T) {
 		},
 		{
 			name:   "Invalid format",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.WebhookCreateRequest{
 				Name:   "Test Webhook",
 				URL:    "https://example.com/webhook",
@@ -158,7 +158,7 @@ func TestWebhookHandler_CreateWebhook(t *testing.T) {
 		},
 		{
 			name:   "Name too long",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.WebhookCreateRequest{
 				Name: string(make([]byte, 101)), // 101 chars
 				URL:  "https://example.com/webhook",
@@ -168,7 +168,7 @@ func TestWebhookHandler_CreateWebhook(t *testing.T) {
 		},
 		{
 			name:   "Default format when not provided",
-			userID: "user-1",
+			userID: "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			requestBody: models.WebhookCreateRequest{
 				Name: "Default Format Webhook",
 				URL:  "https://example.com/webhook",
@@ -242,7 +242,7 @@ func TestWebhookHandler_CreateWebhook_MaxLimit(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		createWebhookDirectly(t, db, &models.Webhook{
 			ID:        "webhook-" + string(rune('0'+i)),
-			UserID:    "user-1",
+			UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 			Name:      "Webhook " + string(rune('0'+i)),
 			URL:       "https://example.com/webhook",
 			Enabled:   true,
@@ -255,7 +255,7 @@ func TestWebhookHandler_CreateWebhook_MaxLimit(t *testing.T) {
 
 	app := fiber.New()
 	app.Post("/webhooks", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.CreateWebhook(c)
 	})
 
@@ -287,8 +287,8 @@ func TestWebhookHandler_GetWebhooks(t *testing.T) {
 
 	// Create test webhooks
 	createWebhookDirectly(t, db, &models.Webhook{
-		ID:        "webhook-1",
-		UserID:    "user-1",
+		ID:        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Webhook 1",
 		URL:       "https://example.com/webhook1",
 		Enabled:   true,
@@ -299,8 +299,8 @@ func TestWebhookHandler_GetWebhooks(t *testing.T) {
 	})
 
 	createWebhookDirectly(t, db, &models.Webhook{
-		ID:        "webhook-2",
-		UserID:    "user-1",
+		ID:        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Webhook 2",
 		URL:       "https://example.com/webhook2",
 		Enabled:   false,
@@ -313,7 +313,7 @@ func TestWebhookHandler_GetWebhooks(t *testing.T) {
 	// Different user's webhook
 	createWebhookDirectly(t, db, &models.Webhook{
 		ID:        "webhook-3",
-		UserID:    "user-2",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
 		Name:      "Other User Webhook",
 		URL:       "https://example.com/webhook3",
 		Enabled:   true,
@@ -325,7 +325,7 @@ func TestWebhookHandler_GetWebhooks(t *testing.T) {
 
 	app := fiber.New()
 	app.Get("/webhooks", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.GetWebhooks(c)
 	})
 
@@ -359,8 +359,8 @@ func TestWebhookHandler_GetWebhook(t *testing.T) {
 	handler := NewWebhookHandler(webhookRepo, nil)
 
 	createWebhookDirectly(t, db, &models.Webhook{
-		ID:        "webhook-1",
-		UserID:    "user-1",
+		ID:        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Test Webhook",
 		URL:       "https://example.com/webhook",
 		Enabled:   true,
@@ -378,20 +378,20 @@ func TestWebhookHandler_GetWebhook(t *testing.T) {
 	}{
 		{
 			name:           "Get existing webhook",
-			userID:         "user-1",
-			webhookID:      "webhook-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Get non-existent webhook",
-			userID:         "user-1",
-			webhookID:      "non-existent",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID:      "99999999-9999-9999-9999-999999999999",
 			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name:           "Get other user's webhook",
-			userID:         "user-2",
-			webhookID:      "webhook-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc2",
+			webhookID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			expectedStatus: http.StatusNotFound,
 		},
 	}
@@ -425,8 +425,8 @@ func TestWebhookHandler_UpdateWebhook(t *testing.T) {
 	handler := NewWebhookHandler(webhookRepo, nil)
 
 	createWebhookDirectly(t, db, &models.Webhook{
-		ID:        "webhook-1",
-		UserID:    "user-1",
+		ID:        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Test Webhook",
 		URL:       "https://example.com/webhook",
 		Enabled:   true,
@@ -449,8 +449,8 @@ func TestWebhookHandler_UpdateWebhook(t *testing.T) {
 	}{
 		{
 			name:      "Update name",
-			userID:    "user-1",
-			webhookID: "webhook-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			requestBody: models.WebhookUpdateRequest{
 				Name: &newName,
 			},
@@ -458,8 +458,8 @@ func TestWebhookHandler_UpdateWebhook(t *testing.T) {
 		},
 		{
 			name:      "Update URL",
-			userID:    "user-1",
-			webhookID: "webhook-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			requestBody: models.WebhookUpdateRequest{
 				URL: &newURL,
 			},
@@ -467,8 +467,8 @@ func TestWebhookHandler_UpdateWebhook(t *testing.T) {
 		},
 		{
 			name:      "Disable webhook",
-			userID:    "user-1",
-			webhookID: "webhook-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			requestBody: models.WebhookUpdateRequest{
 				Enabled: &disabled,
 			},
@@ -476,8 +476,8 @@ func TestWebhookHandler_UpdateWebhook(t *testing.T) {
 		},
 		{
 			name:      "Update non-existent webhook",
-			userID:    "user-1",
-			webhookID: "non-existent",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID: "99999999-9999-9999-9999-999999999999",
 			requestBody: models.WebhookUpdateRequest{
 				Name: &newName,
 			},
@@ -485,8 +485,8 @@ func TestWebhookHandler_UpdateWebhook(t *testing.T) {
 		},
 		{
 			name:      "Update other user's webhook",
-			userID:    "user-2",
-			webhookID: "webhook-1",
+			userID:    "cccccccc-cccc-cccc-cccc-ccccccccccc2",
+			webhookID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			requestBody: models.WebhookUpdateRequest{
 				Name: &newName,
 			},
@@ -526,8 +526,8 @@ func TestWebhookHandler_DeleteWebhook(t *testing.T) {
 	handler := NewWebhookHandler(webhookRepo, nil)
 
 	createWebhookDirectly(t, db, &models.Webhook{
-		ID:        "webhook-1",
-		UserID:    "user-1",
+		ID:        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+		UserID:    "cccccccc-cccc-cccc-cccc-ccccccccccc1",
 		Name:      "Test Webhook",
 		URL:       "https://example.com/webhook",
 		Enabled:   true,
@@ -545,14 +545,14 @@ func TestWebhookHandler_DeleteWebhook(t *testing.T) {
 	}{
 		{
 			name:           "Delete existing webhook",
-			userID:         "user-1",
-			webhookID:      "webhook-1",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
 			expectedStatus: http.StatusNoContent,
 		},
 		{
 			name:           "Delete non-existent webhook",
-			userID:         "user-1",
-			webhookID:      "non-existent",
+			userID:         "cccccccc-cccc-cccc-cccc-ccccccccccc1",
+			webhookID:      "99999999-9999-9999-9999-999999999999",
 			expectedStatus: http.StatusNotFound,
 		},
 	}
@@ -587,7 +587,7 @@ func TestWebhookHandler_InvalidJSON(t *testing.T) {
 
 	app := fiber.New()
 	app.Post("/webhooks", func(c *fiber.Ctx) error {
-		c.Locals("user_id", "user-1")
+		c.Locals("user_id", "cccccccc-cccc-cccc-cccc-ccccccccccc1")
 		return handler.CreateWebhook(c)
 	})
 


### PR DESCRIPTION
Closes #152.

## Symptom

After PR #151 merged, production Postgres started logging:

```
ERROR: invalid input syntax for type uuid: "favicon"
STATEMENT: SELECT id, user_id, name, url, ... FROM services WHERE id = \$1
```

## Root cause

Every \`/.../:id\` handler took the raw \`c.Params("id")\`, checked only that it was non-empty, then passed it straight to Postgres. Any non-UUID \`:id\` (deploy race window, stale tab, future reserved-path collision, garbage URL) crashed through to SQL and surfaced as a 500 + Postgres ERROR log entry.

The likely trigger was the deploy ordering — \`.github/workflows/ci.yml\` builds backend and frontend Docker images independently, so during the PR #151 rollout the new frontend (which calls \`/services/favicon\`) briefly served against the old backend that didn't yet have the \`/favicon\` route.

## Fix

Two layers of defense across every UUID-typed \`:id\` route:

1. **Fiber \`<guid>\` route constraint** at registration — non-UUID paths return 404 at the router *before* any handler runs (no SQL, no Postgres log spam).
2. **\`RequireUUIDParam\` helper** in [handlers/helpers.go](backend/internal/handlers/helpers.go) — used by all 16 affected handlers as belt-and-suspenders. Also applied to UUIDs arriving in JSON bodies (\`validateGroupOwnership\`, \`ReorderServices\`) where route constraints don't help.

Skipped \`/settings/:key\` — not a UUID.

## Scope

- Services: \`GetService\`, \`UpdateService\`, \`DeleteService\`, \`CheckService\`, \`GetRecentStatusLogs\`
- Groups: \`GetGroup\`, \`UpdateGroup\`, \`DeleteGroup\`
- Webhooks: \`GetWebhook\`, \`UpdateWebhook\`, \`DeleteWebhook\`, \`TestWebhook\`, \`GetWebhookLogs\`
- Admin: \`UpdateUserRole\`, \`DeleteUser\`
- Metrics: \`GetServiceMetrics\`, \`GetUserPrometheusMetrics\`
- JSON-body validation: \`validateGroupOwnership\`, \`ReorderServices\`

## Test plan

- [x] \`make ci-check\` green
- [x] New \`TestRequireUUIDParam\` covers happy path, empty, non-UUID (word, garbage, encoded-SQLi, too-short), mixed-case UUID
- [x] New \`TestRouteGuidConstraintRejectsNonUUID\` regression guard — \`/services/favicon\` reaches the static route, \`/services/not-a-uuid\` returns 404 from the router (handler not called), valid UUID reaches the handler
- [x] All existing handler tests updated to use real UUIDs and still pass

## Behavior changes for callers

- Previously: \`GET /services/<non-uuid>\` → 500 + Postgres log spam
- Now: \`GET /services/<non-uuid>\` → 404 (router) or 400 (empty)
- JSON body \`group_id\` that isn't a UUID → 400 \`"Invalid group_id: must be a UUID"\` instead of 500 (\`CreateService\`/\`UpdateService\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route parameters for services, groups, webhooks, metrics and admin user endpoints now enforce UUID format, producing consistent 400/404 responses for malformed or missing IDs.
  * App now returns a uniform JSON 404 response for unmatched or constraint-rejected routes.

* **Tests**
  * Added and updated regression tests to validate UUID route constraints and the JSON 404 behavior across affected endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Turbootzz/Nimbus/pull/153)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->