### PR TITLE
154 bug fix services lose their group assignment after a card size update

### DIFF
--- a/backend/internal/handlers/service_handler.go
+++ b/backend/internal/handlers/service_handler.go
@@ -413,7 +413,14 @@ func (h *ServiceHandler) UpdateService(c *fiber.Ctx) error {
 	existingService.IconImagePath = iconImagePath
 	existingService.Description = req.Description
 	existingService.CardSize = cardSize
-	existingService.GroupID = req.GroupID
+	// GroupID: nil (field omitted) preserves existing; empty string explicitly clears
+	if req.GroupID != nil {
+		if *req.GroupID == "" {
+			existingService.GroupID = nil
+		} else {
+			existingService.GroupID = req.GroupID
+		}
+	}
 	// Update monitoring_enabled if provided
 	if req.MonitoringEnabled != nil {
 		existingService.MonitoringEnabled = *req.MonitoringEnabled

--- a/backend/internal/handlers/service_handler_test.go
+++ b/backend/internal/handlers/service_handler_test.go
@@ -665,6 +665,128 @@ func TestServiceHandler_UpdateService(t *testing.T) {
 	}
 }
 
+// TestServiceHandler_UpdateService_PreservesGroupID covers a regression where
+// resizing a card sent a PUT without group_id and the handler wiped the
+// existing group assignment. The contract is:
+//
+//	group_id omitted (nil pointer)   -> preserve existing
+//	group_id == ""  (empty string)   -> clear the group
+//	group_id == "<uuid>"             -> set to that group (must be owned by user)
+func TestServiceHandler_UpdateService_PreservesGroupID(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	serviceRepo := repository.NewServiceRepository(db)
+	groupRepo := repository.NewGroupRepository(db)
+	handler := NewServiceHandler(serviceRepo, groupRepo, nil)
+
+	userID := "cccccccc-cccc-cccc-cccc-ccccccccccc1"
+	groupID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"
+	serviceID := "11111111-1111-1111-1111-111111111111"
+
+	createGroupDirectly(t, db, &models.Group{
+		ID:                groupID,
+		UserID:            userID,
+		Name:              "My Group",
+		Color:             "#3B82F6",
+		Position:          0,
+		MonitoringEnabled: true,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	})
+
+	createServiceDirectly(t, db, &models.Service{
+		ID:        serviceID,
+		UserID:    userID,
+		Name:      "Service",
+		URL:       "https://example.com",
+		Icon:      "🔗",
+		Status:    models.StatusUnknown,
+		CardSize:  models.CardSize2x1,
+		GroupID:   &groupID,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	})
+
+	put := func(t *testing.T, body []byte) *http.Response {
+		t.Helper()
+		app := fiber.New()
+		app.Put("/services/:id", func(c *fiber.Ctx) error {
+			c.Locals("user_id", userID)
+			return handler.UpdateService(c)
+		})
+		req := httptest.NewRequest(http.MethodPut, "/services/"+serviceID, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("Failed to execute request: %v", err)
+		}
+		return resp
+	}
+
+	currentGroupID := func(t *testing.T) *string {
+		t.Helper()
+		svc, err := serviceRepo.GetByID(context.Background(), serviceID)
+		if err != nil {
+			t.Fatalf("Failed to retrieve service: %v", err)
+		}
+		return svc.GroupID
+	}
+
+	t.Run("omitting group_id preserves the existing assignment", func(t *testing.T) {
+		// PUT body intentionally omits group_id (mirrors the dashboard
+		// resize PUT before the fix).
+		body := []byte(`{"name":"Service","url":"https://example.com","card_size":"2x2"}`)
+		resp := put(t, body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Expected 200, got %d", resp.StatusCode)
+		}
+		gid := currentGroupID(t)
+		if gid == nil || *gid != groupID {
+			t.Errorf("group_id was wiped: got %v, want %q", gid, groupID)
+		}
+	})
+
+	t.Run("explicit empty string clears the group", func(t *testing.T) {
+		body := []byte(`{"name":"Service","url":"https://example.com","group_id":""}`)
+		resp := put(t, body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Expected 200, got %d", resp.StatusCode)
+		}
+		if gid := currentGroupID(t); gid != nil {
+			t.Errorf("group_id should be nil after clear, got %q", *gid)
+		}
+	})
+
+	t.Run("setting group_id restores the assignment", func(t *testing.T) {
+		body := []byte(`{"name":"Service","url":"https://example.com","group_id":"` + groupID + `"}`)
+		resp := put(t, body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Expected 200, got %d", resp.StatusCode)
+		}
+		gid := currentGroupID(t)
+		if gid == nil || *gid != groupID {
+			t.Errorf("group_id not restored: got %v, want %q", gid, groupID)
+		}
+	})
+
+	t.Run("omitting group_id after a clear keeps it cleared", func(t *testing.T) {
+		// First clear, then omit — should remain cleared (preserve nil).
+		clearBody := []byte(`{"name":"Service","url":"https://example.com","group_id":""}`)
+		if resp := put(t, clearBody); resp.StatusCode != http.StatusOK {
+			t.Fatalf("Setup clear failed: %d", resp.StatusCode)
+		}
+		omitBody := []byte(`{"name":"Service","url":"https://example.com","card_size":"2x1"}`)
+		resp := put(t, omitBody)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Expected 200, got %d", resp.StatusCode)
+		}
+		if gid := currentGroupID(t); gid != nil {
+			t.Errorf("group_id should remain cleared, got %q", *gid)
+		}
+	})
+}
+
 func TestServiceHandler_UpdateService_NoAuth(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/backend/internal/models/service.go
+++ b/backend/internal/models/service.go
@@ -82,7 +82,7 @@ type ServiceUpdateRequest struct {
 	IconImagePath     string  `json:"icon_image_path"` // File path or URL for image icons
 	Description       string  `json:"description"`
 	CardSize          string  `json:"card_size"`          // '1x1', '2x1', or '2x2' (preserves existing if empty)
-	GroupID           *string `json:"group_id"`           // Optional group ID (nil clears the group)
+	GroupID           *string `json:"group_id"`           // Omit to preserve existing; empty string clears the group
 	MonitoringEnabled *bool   `json:"monitoring_enabled"` // Optional, preserves existing if nil
 }
 

--- a/frontend/__tests__/lib/monitoring.test.ts
+++ b/frontend/__tests__/lib/monitoring.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import type { Group } from '@/types'
+import { buildGroupMonitoringMap, isServiceEffectivelyMonitored } from '@/lib/monitoring'
+
+const group = (id: string, monitoring_enabled: boolean): Group => ({
+  id,
+  name: id,
+  color: '#000',
+  position: 0,
+  is_default: false,
+  monitoring_enabled,
+  created_at: '2026-01-01T00:00:00Z',
+})
+
+describe('isServiceEffectivelyMonitored', () => {
+  const map = buildGroupMonitoringMap([group('g-on', true), group('g-off', false)])
+
+  it('returns false when the service itself opted out', () => {
+    expect(
+      isServiceEffectivelyMonitored({ monitoring_enabled: false, group_id: 'g-on' }, map)
+    ).toBe(false)
+  })
+
+  it('returns false when the parent group opted out, even if the service did not', () => {
+    expect(
+      isServiceEffectivelyMonitored({ monitoring_enabled: true, group_id: 'g-off' }, map)
+    ).toBe(false)
+  })
+
+  it('returns true when both flags are on', () => {
+    expect(isServiceEffectivelyMonitored({ monitoring_enabled: true, group_id: 'g-on' }, map)).toBe(
+      true
+    )
+  })
+
+  it('returns true for an ungrouped service whose own flag is on', () => {
+    expect(
+      isServiceEffectivelyMonitored({ monitoring_enabled: true, group_id: undefined }, map)
+    ).toBe(true)
+  })
+
+  it('falls back to the service flag when no group map is provided', () => {
+    expect(isServiceEffectivelyMonitored({ monitoring_enabled: true, group_id: 'g-off' })).toBe(
+      true
+    )
+    expect(isServiceEffectivelyMonitored({ monitoring_enabled: false, group_id: 'g-off' })).toBe(
+      false
+    )
+  })
+
+  it('treats an unknown group as monitored (data race tolerance)', () => {
+    expect(
+      isServiceEffectivelyMonitored({ monitoring_enabled: true, group_id: 'missing-from-map' }, map)
+    ).toBe(true)
+  })
+})
+
+describe('buildGroupMonitoringMap', () => {
+  it('returns an empty map for null/undefined input', () => {
+    expect(buildGroupMonitoringMap(null).size).toBe(0)
+    expect(buildGroupMonitoringMap(undefined).size).toBe(0)
+  })
+
+  it('preserves per-group flags', () => {
+    const map = buildGroupMonitoringMap([group('a', true), group('b', false)])
+    expect(map.get('a')).toBe(true)
+    expect(map.get('b')).toBe(false)
+  })
+})

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -338,9 +338,9 @@ export default function DashboardPage() {
       const targetGroup = groups.find((g) => g.id === targetGroupId)
       const isTargetDefault = targetGroup?.is_default
 
-      // For default group: set group_id to null (ungrouped services appear there)
+      // For default group: empty string clears the group (services become ungrouped)
       // For other groups: set group_id to the target group's ID
-      const newGroupId = isTargetDefault ? null : targetGroupId
+      const newGroupId = isTargetDefault ? '' : targetGroupId
 
       // Check if already in the target group
       // Service is in default if: group_id is null/undefined OR matches default group ID
@@ -355,7 +355,7 @@ export default function DashboardPage() {
       // Optimistic update - move service to new group
       setServices(
         services.map((s) =>
-          s.id === activeServiceId ? { ...s, group_id: newGroupId ?? undefined } : s
+          s.id === activeServiceId ? { ...s, group_id: newGroupId || undefined } : s
         )
       )
 
@@ -457,6 +457,7 @@ export default function DashboardPage() {
         icon: freshService.icon || '',
         icon_type: freshService.icon_type || 'emoji',
         icon_image_path: freshService.icon_image_path || '',
+        group_id: freshService.group_id ?? '',
         card_size: newSize,
       })
     } catch (error) {

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -512,7 +512,11 @@ export default function DashboardPage() {
           setGroups(groups.map((g) => (g.id === editingGroup.id ? response.data! : g)))
         }
       } else {
-        const response = await api.createGroup({ name: data.name!, color: data.color })
+        const response = await api.createGroup({
+          name: data.name!,
+          color: data.color,
+          monitoring_enabled: data.monitoring_enabled,
+        })
         if (response.error) {
           throw new Error(response.error.message)
         }

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -32,6 +32,7 @@ import ServiceListItem from '@/components/ServiceListItem'
 import GroupForm from '@/components/GroupForm'
 import DashboardHeader from '@/components/DashboardHeader'
 import ServicesGrid from '@/components/ServicesGrid'
+import { isServiceEffectivelyMonitored } from '@/lib/monitoring'
 
 function toStringId(id: string | number): string {
   return typeof id === 'string' ? id : String(id)
@@ -117,15 +118,10 @@ export default function DashboardPage() {
   const stats = useMemo(() => {
     const servicesToCount = enableServiceGrouping ? filteredServices : services
 
-    // Filter to only monitored services (both service and group monitoring enabled)
-    const monitoredServices = servicesToCount.filter((s) => {
-      if (!s.monitoring_enabled) return false
-      if (s.group_id) {
-        const groupMonitoring = groupMonitoringMap.get(s.group_id)
-        if (groupMonitoring === false) return false
-      }
-      return true
-    })
+    // Filter to only effectively-monitored services (both service and group flag on)
+    const monitoredServices = servicesToCount.filter((s) =>
+      isServiceEffectivelyMonitored(s, groupMonitoringMap)
+    )
 
     const online = monitoredServices.filter((s) => s.status === 'online').length
     const offline = monitoredServices.filter((s) => s.status === 'offline').length
@@ -658,6 +654,7 @@ export default function DashboardPage() {
               viewMode={viewMode}
               isEditMode={isEditMode}
               onSizeChange={handleSizeChange}
+              groupMonitoringMap={groupMonitoringMap}
             />
           </SortableContext>
 
@@ -669,6 +666,7 @@ export default function DashboardPage() {
                   openInNewTab={openInNewTab}
                   isEditMode={true}
                   isDragging={true}
+                  isMonitored={isServiceEffectivelyMonitored(activeService, groupMonitoringMap)}
                 />
               ) : (
                 <ServiceCard
@@ -679,6 +677,7 @@ export default function DashboardPage() {
                   isDragging={true}
                   enableCardResizing={enableCardResizing}
                   cardScale={cardScale}
+                  isMonitored={isServiceEffectivelyMonitored(activeService, groupMonitoringMap)}
                 />
               ))}
           </DragOverlay>
@@ -706,6 +705,7 @@ export default function DashboardPage() {
             enableCardResizing={enableCardResizing}
             cardScale={cardScale}
             viewMode={viewMode}
+            groupMonitoringMap={groupMonitoringMap}
           />
         </>
       )}

--- a/frontend/app/(dashboard)/metrics/page.tsx
+++ b/frontend/app/(dashboard)/metrics/page.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { ChartBarIcon, ServerIcon } from '@heroicons/react/24/outline'
 import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/solid'
-import { Service, Group } from '@/types'
+import { Service } from '@/types'
 import { api } from '@/lib/api'
+import { buildGroupMonitoringMap, isServiceEffectivelyMonitored } from '@/lib/monitoring'
 import CombinedMetricsChart from '@/components/graphs/CombinedMetricsChart'
 import ServiceIcon from '@/components/ServiceIcon'
 
@@ -29,27 +30,11 @@ export default function MetricsPage() {
         if (servicesResponse.data) {
           const allServices = servicesResponse.data
           const groups = groupsResponse.data || []
+          const groupMonitoringMap = buildGroupMonitoringMap(groups)
 
-          // Create a map of group IDs to their monitoring status
-          const groupMonitoringMap = new Map<string, boolean>()
-          groups.forEach((g: Group) => {
-            groupMonitoringMap.set(g.id, g.monitoring_enabled)
-          })
-
-          // Filter services: must have monitoring enabled AND group (if any) must have monitoring enabled
-          const monitoredServices = allServices.filter((s) => {
-            // Service must have monitoring enabled
-            if (!s.monitoring_enabled) return false
-
-            // If service has a group, check group's monitoring status
-            if (s.group_id) {
-              const groupMonitoring = groupMonitoringMap.get(s.group_id)
-              // If group exists and has monitoring disabled, exclude service
-              if (groupMonitoring === false) return false
-            }
-
-            return true
-          })
+          const monitoredServices = allServices.filter((s) =>
+            isServiceEffectivelyMonitored(s, groupMonitoringMap)
+          )
 
           setServices(monitoredServices)
         }

--- a/frontend/app/(dashboard)/services/[id]/edit/page.tsx
+++ b/frontend/app/(dashboard)/services/[id]/edit/page.tsx
@@ -140,7 +140,7 @@ export default function EditServicePage() {
         icon_type: formData.icon_type,
         icon_image_path: iconImagePath,
         description: formData.description.trim(),
-        group_id: enableServiceGrouping ? formData.group_id || null : undefined,
+        group_id: enableServiceGrouping ? formData.group_id : undefined,
         monitoring_enabled: formData.monitoring_enabled,
       })
 

--- a/frontend/app/(dashboard)/services/[id]/edit/page.tsx
+++ b/frontend/app/(dashboard)/services/[id]/edit/page.tsx
@@ -36,6 +36,20 @@ export default function EditServicePage() {
     monitoring_enabled: true,
   })
 
+  // The backend skips health checks for services in groups that have monitoring
+  // disabled, so allowing the user to flip this on would only produce a stuck
+  // "unknown" status. Lock the toggle off whenever the selected group opts out.
+  const selectedGroup = enableServiceGrouping
+    ? groups.find((g) => g.id === formData.group_id)
+    : undefined
+  const groupMonitoringDisabled = selectedGroup?.monitoring_enabled === false
+
+  useEffect(() => {
+    if (groupMonitoringDisabled && formData.monitoring_enabled) {
+      setFormData((prev) => ({ ...prev, monitoring_enabled: false }))
+    }
+  }, [groupMonitoringDisabled, formData.monitoring_enabled])
+
   // Fetch service data
   useEffect(() => {
     const fetchService = async () => {
@@ -323,8 +337,12 @@ export default function EditServicePage() {
               setFormData((prev) => ({ ...prev, monitoring_enabled: enabled }))
             }
             label="Enable Monitoring"
-            description="When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
-            disabled={isSaving}
+            description={
+              groupMonitoringDisabled
+                ? `Monitoring is disabled for the "${selectedGroup?.name}" group, so services in it are never health-checked`
+                : "When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
+            }
+            disabled={isSaving || groupMonitoringDisabled}
           />
 
           {/* Form Actions */}

--- a/frontend/app/(dashboard)/services/[id]/edit/page.tsx
+++ b/frontend/app/(dashboard)/services/[id]/edit/page.tsx
@@ -11,6 +11,7 @@ import GroupSelector from '@/components/GroupSelector'
 import { Toggle } from '@/components/ui/Toggle'
 import type { IconType, Group } from '@/types'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useGroupMonitoringLock } from '@/hooks/useGroupMonitoringLock'
 
 export default function EditServicePage() {
   const router = useRouter()
@@ -36,19 +37,13 @@ export default function EditServicePage() {
     monitoring_enabled: true,
   })
 
-  // The backend skips health checks for services in groups that have monitoring
-  // disabled, so allowing the user to flip this on would only produce a stuck
-  // "unknown" status. Lock the toggle off whenever the selected group opts out.
-  const selectedGroup = enableServiceGrouping
-    ? groups.find((g) => g.id === formData.group_id)
-    : undefined
-  const groupMonitoringDisabled = selectedGroup?.monitoring_enabled === false
-
-  useEffect(() => {
-    if (groupMonitoringDisabled && formData.monitoring_enabled) {
-      setFormData((prev) => ({ ...prev, monitoring_enabled: false }))
-    }
-  }, [groupMonitoringDisabled, formData.monitoring_enabled])
+  const { groupMonitoringDisabled, monitoringDescription } = useGroupMonitoringLock({
+    groups,
+    selectedGroupId: formData.group_id,
+    enableServiceGrouping,
+    monitoringEnabled: formData.monitoring_enabled,
+    setMonitoringEnabled: (next) => setFormData((prev) => ({ ...prev, monitoring_enabled: next })),
+  })
 
   // Fetch service data
   useEffect(() => {
@@ -337,11 +332,7 @@ export default function EditServicePage() {
               setFormData((prev) => ({ ...prev, monitoring_enabled: enabled }))
             }
             label="Enable Monitoring"
-            description={
-              groupMonitoringDisabled
-                ? `Monitoring is disabled for the "${selectedGroup?.name}" group, so services in it are never health-checked`
-                : "When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
-            }
+            description={monitoringDescription}
             disabled={isSaving || groupMonitoringDisabled}
           />
 

--- a/frontend/app/(dashboard)/services/new/page.tsx
+++ b/frontend/app/(dashboard)/services/new/page.tsx
@@ -11,6 +11,7 @@ import GroupSelector from '@/components/GroupSelector'
 import { Toggle } from '@/components/ui/Toggle'
 import type { IconType, Group } from '@/types'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useGroupMonitoringLock } from '@/hooks/useGroupMonitoringLock'
 
 function NewServiceContent() {
   const router = useRouter()
@@ -34,19 +35,13 @@ function NewServiceContent() {
     monitoring_enabled: true,
   })
 
-  // The backend skips health checks for services in groups that have monitoring
-  // disabled, so allowing the user to flip this on would only produce a stuck
-  // "unknown" status. Lock the toggle off whenever the selected group opts out.
-  const selectedGroup = enableServiceGrouping
-    ? groups.find((g) => g.id === formData.group_id)
-    : undefined
-  const groupMonitoringDisabled = selectedGroup?.monitoring_enabled === false
-
-  useEffect(() => {
-    if (groupMonitoringDisabled && formData.monitoring_enabled) {
-      setFormData((prev) => ({ ...prev, monitoring_enabled: false }))
-    }
-  }, [groupMonitoringDisabled, formData.monitoring_enabled])
+  const { groupMonitoringDisabled, monitoringDescription } = useGroupMonitoringLock({
+    groups,
+    selectedGroupId: formData.group_id,
+    enableServiceGrouping,
+    monitoringEnabled: formData.monitoring_enabled,
+    setMonitoringEnabled: (next) => setFormData((prev) => ({ ...prev, monitoring_enabled: next })),
+  })
 
   // Fetch groups when grouping is enabled
   useEffect(() => {
@@ -305,11 +300,7 @@ function NewServiceContent() {
               setFormData((prev) => ({ ...prev, monitoring_enabled: enabled }))
             }
             label="Enable Monitoring"
-            description={
-              groupMonitoringDisabled
-                ? `Monitoring is disabled for the "${selectedGroup?.name}" group, so services in it are never health-checked`
-                : "When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
-            }
+            description={monitoringDescription}
             disabled={isLoading || groupMonitoringDisabled}
           />
 

--- a/frontend/app/(dashboard)/services/new/page.tsx
+++ b/frontend/app/(dashboard)/services/new/page.tsx
@@ -34,6 +34,20 @@ function NewServiceContent() {
     monitoring_enabled: true,
   })
 
+  // The backend skips health checks for services in groups that have monitoring
+  // disabled, so allowing the user to flip this on would only produce a stuck
+  // "unknown" status. Lock the toggle off whenever the selected group opts out.
+  const selectedGroup = enableServiceGrouping
+    ? groups.find((g) => g.id === formData.group_id)
+    : undefined
+  const groupMonitoringDisabled = selectedGroup?.monitoring_enabled === false
+
+  useEffect(() => {
+    if (groupMonitoringDisabled && formData.monitoring_enabled) {
+      setFormData((prev) => ({ ...prev, monitoring_enabled: false }))
+    }
+  }, [groupMonitoringDisabled, formData.monitoring_enabled])
+
   // Fetch groups when grouping is enabled
   useEffect(() => {
     const fetchGroups = async () => {
@@ -291,8 +305,12 @@ function NewServiceContent() {
               setFormData((prev) => ({ ...prev, monitoring_enabled: enabled }))
             }
             label="Enable Monitoring"
-            description="When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
-            disabled={isLoading}
+            description={
+              groupMonitoringDisabled
+                ? `Monitoring is disabled for the "${selectedGroup?.name}" group, so services in it are never health-checked`
+                : "When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
+            }
+            disabled={isLoading || groupMonitoringDisabled}
           />
 
           {/* Form Actions */}

--- a/frontend/app/(dashboard)/services/page.tsx
+++ b/frontend/app/(dashboard)/services/page.tsx
@@ -16,12 +16,14 @@ import {
 } from '@dnd-kit/core'
 import { arrayMove, SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
 import { api } from '@/lib/api'
-import type { Service } from '@/types'
+import type { Service, Group } from '@/types'
 import { DraggableServiceManagementCard } from '@/components/DraggableServiceManagementCard'
 import { ServiceManagementCardPresentation } from '@/components/ServiceManagementCardPresentation'
+import { buildGroupMonitoringMap, isServiceEffectivelyMonitored } from '@/lib/monitoring'
 
 export default function ServicesPage() {
   const [services, setServices] = useState<Service[]>([])
+  const [groups, setGroups] = useState<Group[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -50,12 +52,21 @@ export default function ServicesPage() {
     setError('')
 
     try {
-      const response = await api.getServices()
+      const [servicesResponse, groupsResponse] = await Promise.all([
+        api.getServices(),
+        api.getGroups(),
+      ])
 
-      if (response.error) {
-        setError(response.error.message)
-      } else if (response.data) {
-        setServices(response.data)
+      if (servicesResponse.error) {
+        setError(servicesResponse.error.message)
+      } else if (servicesResponse.data) {
+        setServices(servicesResponse.data)
+      }
+
+      // Groups are only used to derive monitoring state, so a failure here is
+      // non-fatal — fall back to the service-level flag.
+      if (groupsResponse.data) {
+        setGroups(groupsResponse.data)
       }
     } catch (error) {
       console.error('Failed to fetch services:', error)
@@ -150,6 +161,7 @@ export default function ServicesPage() {
   }
 
   const activeService = services.find((s) => s.id === activeId)
+  const groupMonitoringMap = buildGroupMonitoringMap(groups)
 
   return (
     <div>
@@ -215,6 +227,7 @@ export default function ServicesPage() {
                   key={service.id}
                   service={service}
                   onDelete={handleDelete}
+                  isMonitored={isServiceEffectivelyMonitored(service, groupMonitoringMap)}
                 />
               ))}
             </div>
@@ -226,6 +239,7 @@ export default function ServicesPage() {
                 service={activeService}
                 onDelete={handleDelete}
                 style={{ opacity: 0.5 }}
+                isMonitored={isServiceEffectivelyMonitored(activeService, groupMonitoringMap)}
               />
             ) : null}
           </DragOverlay>

--- a/frontend/app/(dashboard)/services/page.tsx
+++ b/frontend/app/(dashboard)/services/page.tsx
@@ -52,21 +52,29 @@ export default function ServicesPage() {
     setError('')
 
     try {
-      const [servicesResponse, groupsResponse] = await Promise.all([
+      // allSettled (vs Promise.all): groups are only used to derive monitoring
+      // state, so a groups failure must not abort the services render.
+      const [servicesSettled, groupsSettled] = await Promise.allSettled([
         api.getServices(),
         api.getGroups(),
       ])
 
-      if (servicesResponse.error) {
-        setError(servicesResponse.error.message)
-      } else if (servicesResponse.data) {
-        setServices(servicesResponse.data)
+      if (servicesSettled.status === 'fulfilled') {
+        const servicesResponse = servicesSettled.value
+        if (servicesResponse.error) {
+          setError(servicesResponse.error.message)
+        } else if (servicesResponse.data) {
+          setServices(servicesResponse.data)
+        }
+      } else {
+        console.error('Failed to fetch services:', servicesSettled.reason)
+        setError('Unable to load services. Please try again.')
       }
 
-      // Groups are only used to derive monitoring state, so a failure here is
-      // non-fatal — fall back to the service-level flag.
-      if (groupsResponse.data) {
-        setGroups(groupsResponse.data)
+      if (groupsSettled.status === 'fulfilled' && groupsSettled.value.data) {
+        setGroups(groupsSettled.value.data)
+      } else if (groupsSettled.status === 'rejected') {
+        console.error('Failed to fetch groups:', groupsSettled.reason)
       }
     } catch (error) {
       console.error('Failed to fetch services:', error)

--- a/frontend/components/DraggableServiceManagementCard.tsx
+++ b/frontend/components/DraggableServiceManagementCard.tsx
@@ -14,13 +14,18 @@ import ServiceIcon from '@/components/ServiceIcon'
 interface DraggableServiceManagementCardProps {
   service: Service
   onDelete: (id: string, name: string) => void
+  // Effective monitoring state (accounts for the group's monitoring flag too).
+  // Defaults to service.monitoring_enabled when not provided.
+  isMonitored?: boolean
 }
 
 export function DraggableServiceManagementCard({
   service,
   onDelete,
+  isMonitored,
 }: DraggableServiceManagementCardProps) {
   const { openInNewTab } = useTheme()
+  const monitored = isMonitored ?? service.monitoring_enabled
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: service.id,
@@ -51,10 +56,14 @@ export function DraggableServiceManagementCard({
           >
             <Bars3Icon className="text-text-muted h-5 w-5" />
           </div>
-          <div className={`order-1 flex items-center ${getStatusColor(service.status)}`}>
-            {getStatusIcon(service.status)}
-            <span className="ml-1 text-sm capitalize">{service.status}</span>
-          </div>
+          {monitored ? (
+            <div className={`order-1 flex items-center ${getStatusColor(service.status)}`}>
+              {getStatusIcon(service.status)}
+              <span className="ml-1 text-sm capitalize">{service.status}</span>
+            </div>
+          ) : (
+            <span className="text-text-muted order-1 text-xs">Not monitored</span>
+          )}
         </div>
       </div>
 
@@ -78,7 +87,8 @@ export function DraggableServiceManagementCard({
 
       {/* Response time and last checked */}
       <div className="text-text-muted mb-4 space-y-1 text-xs">
-        {service.status === 'online' &&
+        {monitored &&
+          service.status === 'online' &&
           service.response_time !== undefined &&
           service.response_time !== null && (
             <div className="flex items-center">
@@ -88,7 +98,7 @@ export function DraggableServiceManagementCard({
               </span>
             </div>
           )}
-        {service.updated_at && service.status !== 'unknown' && (
+        {monitored && service.updated_at && service.status !== 'unknown' && (
           <div className="flex items-center">
             <ClockIcon className="mr-1 h-3 w-3" />
             Last checked: {formatRelativeTime(service.updated_at)}

--- a/frontend/components/DraggableServiceManagementCard.tsx
+++ b/frontend/components/DraggableServiceManagementCard.tsx
@@ -41,7 +41,7 @@ export function DraggableServiceManagementCard({
     <div
       ref={setNodeRef}
       style={style}
-      className="bg-card border-card-border group relative rounded-lg border p-6 transition-all hover:shadow-lg"
+      className="bg-card border-card-border group relative flex h-full flex-col rounded-lg border p-6 transition-all hover:shadow-lg"
     >
       {/* Service icon and status */}
       <div className="mb-4 flex items-start justify-between">
@@ -108,7 +108,7 @@ export function DraggableServiceManagementCard({
 
       {/* Actions */}
       <div
-        className="flex items-center gap-2 border-t pt-4"
+        className="mt-auto flex items-center gap-2 border-t pt-4"
         style={{ borderColor: 'var(--color-card-border)' }}
       >
         <Link

--- a/frontend/components/ServiceCard.tsx
+++ b/frontend/components/ServiceCard.tsx
@@ -21,6 +21,9 @@ interface ServiceCardProps {
   isDragging?: boolean
   enableCardResizing?: boolean
   cardScale?: CardScale
+  // Effective monitoring state (accounts for the group's monitoring flag too).
+  // Defaults to service.monitoring_enabled when not provided.
+  isMonitored?: boolean
 }
 
 export default function ServiceCard({
@@ -32,7 +35,9 @@ export default function ServiceCard({
   isDragging = false,
   enableCardResizing = true,
   cardScale = 'medium',
+  isMonitored,
 }: ServiceCardProps) {
+  const monitored = isMonitored ?? service.monitoring_enabled
   // When card resizing is disabled, always use 2x1
   const cardSize = enableCardResizing ? service.card_size || '2x1' : '2x1'
   // In edit mode, the wrapper div handles grid spanning, so card just fills container
@@ -62,6 +67,7 @@ export default function ServiceCard({
     cardSize,
     showSizeBadge: enableCardResizing,
     cardScale,
+    monitored,
   }
 
   // When resizing is disabled, always use StandardCard (2x1)
@@ -94,6 +100,7 @@ interface CardVariantProps {
   cardSize: CardSize
   showSizeBadge: boolean
   cardScale: CardScale
+  monitored: boolean
 }
 
 // Icon sizes based on cardScale - icons shrink with denser grids
@@ -167,6 +174,7 @@ function CompactCard({
   cardSize,
   showSizeBadge,
   cardScale,
+  monitored,
 }: CardVariantProps) {
   const padding = scalePadding[cardScale].compact
   const iconSize = scaleIconSizes[cardScale].large
@@ -194,7 +202,7 @@ function CompactCard({
       </div>
       {/* Title with inline status indicator */}
       <div className="flex w-full items-center justify-center gap-1.5">
-        {service.monitoring_enabled && (
+        {monitored && (
           <div
             className={`${statusDotSize} shrink-0 rounded-full ${getStatusBgColor(service.status)}`}
           />
@@ -231,6 +239,7 @@ function StandardCard({
   cardSize,
   showSizeBadge,
   cardScale,
+  monitored,
 }: CardVariantProps) {
   const padding = scalePadding[cardScale].standard
   const iconSize = scaleIconSizes[cardScale].standard
@@ -255,7 +264,7 @@ function StandardCard({
       )}
       <div className={`${marginBottom} flex items-start justify-between`}>
         <ServiceIcon service={service} size={iconSize} />
-        {service.monitoring_enabled ? (
+        {monitored ? (
           <div className={`flex items-center ${getStatusColor(service.status)}`}>
             {getStatusIcon(service.status)}
             <span className="ml-1 text-sm capitalize">{service.status}</span>
@@ -272,7 +281,7 @@ function StandardCard({
         <p className={`text-text-secondary line-clamp-1 ${descSize}`}>{service.description}</p>
       )}
 
-      {service.monitoring_enabled && (
+      {monitored && (
         <div
           className={`mt-auto flex items-center py-1 text-xs ${service.status === 'online' && service.response_time !== undefined && service.response_time !== null ? getResponseTimeColor(service.response_time) : 'text-transparent'}`}
         >
@@ -314,6 +323,7 @@ function LargeCard({
   cardSize,
   showSizeBadge,
   cardScale,
+  monitored,
 }: CardVariantProps) {
   const padding = scalePadding[cardScale].standard
   const iconSize = scaleIconSizes[cardScale].large
@@ -344,7 +354,7 @@ function LargeCard({
       )}
       {/* Status in top right */}
       <div className={`${marginBottom} flex justify-end`}>
-        {service.monitoring_enabled ? (
+        {monitored ? (
           <div className={`flex items-center text-sm ${getStatusColor(service.status)}`}>
             {getStatusIcon(service.status)}
             <span className="ml-1 capitalize">{service.status}</span>
@@ -370,7 +380,7 @@ function LargeCard({
       {/* Footer with URL and response time */}
       <div className={`${marginTop} space-y-2`}>
         <div className="text-text-muted truncate text-center text-xs">{service.url}</div>
-        {service.monitoring_enabled &&
+        {monitored &&
           service.status === 'online' &&
           service.response_time !== undefined &&
           service.response_time !== null && (

--- a/frontend/components/ServiceListItem.tsx
+++ b/frontend/components/ServiceListItem.tsx
@@ -76,7 +76,12 @@ export default function ServiceListItem({
             </span>
           </>
         ) : (
-          <span className="text-text-muted hidden text-xs sm:inline">Not monitored</span>
+          <>
+            {/* Muted dot on mobile mirrors the monitored layout so the row */}
+            {/* doesn't collapse into having no status indicator at all. */}
+            <div className="h-2 w-2 rounded-full bg-gray-400" />
+            <span className="text-text-muted hidden text-xs sm:inline">Not monitored</span>
+          </>
         )}
       </div>
 

--- a/frontend/components/ServiceListItem.tsx
+++ b/frontend/components/ServiceListItem.tsx
@@ -12,6 +12,9 @@ interface ServiceListItemProps {
   isEditMode?: boolean
   dragHandleProps?: Record<string, unknown>
   isDragging?: boolean
+  // Effective monitoring state (accounts for the group's monitoring flag too).
+  // Defaults to service.monitoring_enabled when not provided.
+  isMonitored?: boolean
 }
 
 export default function ServiceListItem({
@@ -20,7 +23,9 @@ export default function ServiceListItem({
   isEditMode = false,
   dragHandleProps,
   isDragging = false,
+  isMonitored,
 }: ServiceListItemProps) {
+  const monitored = isMonitored ?? service.monitoring_enabled
   const linkProps = {
     href: service.url,
     target: openInNewTab ? '_blank' : '_self',
@@ -63,14 +68,21 @@ export default function ServiceListItem({
 
       {/* Status indicator - compact dot style */}
       <div className="flex shrink-0 items-center gap-1.5">
-        <div className={`h-2 w-2 rounded-full ${getStatusBgColor(service.status)}`} />
-        <span className="text-text-secondary hidden text-xs capitalize sm:inline">
-          {service.status}
-        </span>
+        {monitored ? (
+          <>
+            <div className={`h-2 w-2 rounded-full ${getStatusBgColor(service.status)}`} />
+            <span className="text-text-secondary hidden text-xs capitalize sm:inline">
+              {service.status}
+            </span>
+          </>
+        ) : (
+          <span className="text-text-muted hidden text-xs sm:inline">Not monitored</span>
+        )}
       </div>
 
       {/* Response time - only show for online services */}
-      {service.status === 'online' &&
+      {monitored &&
+        service.status === 'online' &&
         service.response_time !== undefined &&
         service.response_time !== null && (
           <div

--- a/frontend/components/ServiceManagementCardPresentation.tsx
+++ b/frontend/components/ServiceManagementCardPresentation.tsx
@@ -12,6 +12,9 @@ interface ServiceManagementCardPresentationProps {
   service: Service
   onDelete: (id: string, name: string) => void
   style?: React.CSSProperties
+  // Effective monitoring state (accounts for the group's monitoring flag too).
+  // Defaults to service.monitoring_enabled when not provided.
+  isMonitored?: boolean
 }
 
 // Presentation-only component for DragOverlay (no useSortable hook)
@@ -19,8 +22,10 @@ export function ServiceManagementCardPresentation({
   service,
   onDelete,
   style,
+  isMonitored,
 }: ServiceManagementCardPresentationProps) {
   const { openInNewTab } = useTheme()
+  const monitored = isMonitored ?? service.monitoring_enabled
 
   return (
     <div
@@ -31,10 +36,14 @@ export function ServiceManagementCardPresentation({
       <div className="mb-4 flex items-start justify-between">
         <ServiceIcon service={service} size="md" />
         <div className="flex items-center gap-3">
-          <div className={`order-1 flex items-center ${getStatusColor(service.status)}`}>
-            {getStatusIcon(service.status)}
-            <span className="ml-1 text-sm capitalize">{service.status}</span>
-          </div>
+          {monitored ? (
+            <div className={`order-1 flex items-center ${getStatusColor(service.status)}`}>
+              {getStatusIcon(service.status)}
+              <span className="ml-1 text-sm capitalize">{service.status}</span>
+            </div>
+          ) : (
+            <span className="text-text-muted order-1 text-xs">Not monitored</span>
+          )}
         </div>
       </div>
 
@@ -52,7 +61,8 @@ export function ServiceManagementCardPresentation({
 
       {/* Response time and last checked */}
       <div className="text-text-muted mb-4 space-y-1 text-xs">
-        {service.status === 'online' &&
+        {monitored &&
+          service.status === 'online' &&
           service.response_time !== undefined &&
           service.response_time !== null && (
             <div className="flex items-center">
@@ -62,7 +72,7 @@ export function ServiceManagementCardPresentation({
               </span>
             </div>
           )}
-        {service.updated_at && service.status !== 'unknown' && (
+        {monitored && service.updated_at && service.status !== 'unknown' && (
           <div className="flex items-center">
             <ClockIcon className="mr-1 h-3 w-3" />
             Last checked: {formatRelativeTime(service.updated_at)}

--- a/frontend/components/ServiceManagementCardPresentation.tsx
+++ b/frontend/components/ServiceManagementCardPresentation.tsx
@@ -30,7 +30,7 @@ export function ServiceManagementCardPresentation({
   return (
     <div
       style={style}
-      className="bg-card border-card-border group relative rounded-lg border p-6 transition-all hover:shadow-lg"
+      className="bg-card border-card-border group relative flex h-full flex-col rounded-lg border p-6 transition-all hover:shadow-lg"
     >
       {/* Service icon and status */}
       <div className="mb-4 flex items-start justify-between">
@@ -82,7 +82,7 @@ export function ServiceManagementCardPresentation({
 
       {/* Actions */}
       <div
-        className="flex items-center gap-2 border-t pt-4"
+        className="mt-auto flex items-center gap-2 border-t pt-4"
         style={{ borderColor: 'var(--color-card-border)' }}
       >
         <Link

--- a/frontend/components/ServicesGrid.tsx
+++ b/frontend/components/ServicesGrid.tsx
@@ -4,6 +4,7 @@ import type { Service, CardSize, CardScale, ViewMode } from '@/types'
 import ServiceCard from '@/components/ServiceCard'
 import SortableServiceCard from '@/components/SortableServiceCard'
 import ServicesList from '@/components/ServicesList'
+import { isServiceEffectivelyMonitored, type GroupMonitoringMap } from '@/lib/monitoring'
 
 // Grid classes for different card scales
 // Mobile always uses large layout (grid-cols-2) to avoid clutter
@@ -22,6 +23,7 @@ interface ServicesGridProps {
   viewMode: ViewMode
   isEditMode?: boolean
   onSizeChange?: (id: string, newSize: CardSize) => void
+  groupMonitoringMap?: GroupMonitoringMap
 }
 
 export default function ServicesGrid({
@@ -32,15 +34,24 @@ export default function ServicesGrid({
   viewMode,
   isEditMode = false,
   onSizeChange,
+  groupMonitoringMap,
 }: ServicesGridProps) {
   // Render list view if viewMode is 'list'
   if (viewMode === 'list') {
-    return <ServicesList services={services} openInNewTab={openInNewTab} isEditMode={isEditMode} />
+    return (
+      <ServicesList
+        services={services}
+        openInNewTab={openInNewTab}
+        isEditMode={isEditMode}
+        groupMonitoringMap={groupMonitoringMap}
+      />
+    )
   }
 
   // Render grid view
-  const gridContent = services.map((service) =>
-    isEditMode && onSizeChange ? (
+  const gridContent = services.map((service) => {
+    const monitored = isServiceEffectivelyMonitored(service, groupMonitoringMap)
+    return isEditMode && onSizeChange ? (
       <SortableServiceCard
         key={service.id}
         service={service}
@@ -49,6 +60,7 @@ export default function ServicesGrid({
         onSizeChange={onSizeChange}
         enableCardResizing={enableCardResizing}
         cardScale={cardScale}
+        isMonitored={monitored}
       />
     ) : (
       <ServiceCard
@@ -57,9 +69,10 @@ export default function ServicesGrid({
         openInNewTab={openInNewTab}
         enableCardResizing={enableCardResizing}
         cardScale={cardScale}
+        isMonitored={monitored}
       />
     )
-  )
+  })
 
   return (
     <div className={`grid ${gridClasses[cardScale]}`} style={{ gridAutoFlow: 'dense' }}>

--- a/frontend/components/ServicesList.tsx
+++ b/frontend/components/ServicesList.tsx
@@ -3,27 +3,41 @@
 import type { Service } from '@/types'
 import ServiceListItem from '@/components/ServiceListItem'
 import SortableServiceListItem from '@/components/SortableServiceListItem'
+import { isServiceEffectivelyMonitored, type GroupMonitoringMap } from '@/lib/monitoring'
 
 interface ServicesListProps {
   services: Service[]
   openInNewTab: boolean
   isEditMode?: boolean
+  groupMonitoringMap?: GroupMonitoringMap
 }
 
 export default function ServicesList({
   services,
   openInNewTab,
   isEditMode = false,
+  groupMonitoringMap,
 }: ServicesListProps) {
   return (
     <div className="grid grid-cols-1 gap-x-3 gap-y-1 lg:grid-cols-2 2xl:grid-cols-3">
-      {services.map((service) =>
-        isEditMode ? (
-          <SortableServiceListItem key={service.id} service={service} openInNewTab={openInNewTab} />
+      {services.map((service) => {
+        const monitored = isServiceEffectivelyMonitored(service, groupMonitoringMap)
+        return isEditMode ? (
+          <SortableServiceListItem
+            key={service.id}
+            service={service}
+            openInNewTab={openInNewTab}
+            isMonitored={monitored}
+          />
         ) : (
-          <ServiceListItem key={service.id} service={service} openInNewTab={openInNewTab} />
+          <ServiceListItem
+            key={service.id}
+            service={service}
+            openInNewTab={openInNewTab}
+            isMonitored={monitored}
+          />
         )
-      )}
+      })}
     </div>
   )
 }

--- a/frontend/components/SortableServiceCard.tsx
+++ b/frontend/components/SortableServiceCard.tsx
@@ -12,6 +12,7 @@ interface SortableServiceCardProps {
   onSizeChange: (id: string, newSize: CardSize) => void
   enableCardResizing: boolean
   cardScale: CardScale
+  isMonitored?: boolean
 }
 
 export default function SortableServiceCard({
@@ -21,6 +22,7 @@ export default function SortableServiceCard({
   onSizeChange,
   enableCardResizing,
   cardScale,
+  isMonitored,
 }: SortableServiceCardProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useSortable({
     id: service.id,
@@ -48,6 +50,7 @@ export default function SortableServiceCard({
         isDragging={false}
         enableCardResizing={enableCardResizing}
         cardScale={cardScale}
+        isMonitored={isMonitored}
       />
     </div>
   )

--- a/frontend/components/SortableServiceListItem.tsx
+++ b/frontend/components/SortableServiceListItem.tsx
@@ -8,11 +8,13 @@ import ServiceListItem from '@/components/ServiceListItem'
 interface SortableServiceListItemProps {
   service: Service
   openInNewTab: boolean
+  isMonitored?: boolean
 }
 
 export default function SortableServiceListItem({
   service,
   openInNewTab,
+  isMonitored,
 }: SortableServiceListItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: service.id,
@@ -33,6 +35,7 @@ export default function SortableServiceListItem({
         isEditMode={true}
         dragHandleProps={{ ...attributes, ...listeners }}
         isDragging={isDragging}
+        isMonitored={isMonitored}
       />
     </div>
   )

--- a/frontend/hooks/useGroupMonitoringLock.ts
+++ b/frontend/hooks/useGroupMonitoringLock.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { Group } from '@/types'
 
 const DEFAULT_MONITORING_DESCRIPTION =
@@ -41,11 +41,19 @@ export function useGroupMonitoringLock({
     : undefined
   const groupMonitoringDisabled = selectedGroup?.monitoring_enabled === false
 
+  // Callers pass an inline setter (new identity each render). Keep the latest
+  // setter in a ref, synced via an effect, so the force-off effect below can
+  // depend on the booleans only and not re-fire on every parent render.
+  const setMonitoringEnabledRef = useRef(setMonitoringEnabled)
+  useEffect(() => {
+    setMonitoringEnabledRef.current = setMonitoringEnabled
+  }, [setMonitoringEnabled])
+
   useEffect(() => {
     if (groupMonitoringDisabled && monitoringEnabled) {
-      setMonitoringEnabled(false)
+      setMonitoringEnabledRef.current(false)
     }
-  }, [groupMonitoringDisabled, monitoringEnabled, setMonitoringEnabled])
+  }, [groupMonitoringDisabled, monitoringEnabled])
 
   const monitoringDescription = groupMonitoringDisabled
     ? `Monitoring is disabled for the "${selectedGroup?.name}" group, so services in it are never health-checked`

--- a/frontend/hooks/useGroupMonitoringLock.ts
+++ b/frontend/hooks/useGroupMonitoringLock.ts
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { Group } from '@/types'
+
+const DEFAULT_MONITORING_DESCRIPTION =
+  "When disabled, this service won't be health-checked and won't appear in metrics or trigger webhooks"
+
+interface UseGroupMonitoringLockArgs {
+  groups: Group[]
+  selectedGroupId: string
+  enableServiceGrouping: boolean
+  monitoringEnabled: boolean
+  setMonitoringEnabled: (next: boolean) => void
+}
+
+interface UseGroupMonitoringLockResult {
+  selectedGroup: Group | undefined
+  // True when the selected group has opted out of monitoring, in which case
+  // the form's monitoring toggle must be locked off.
+  groupMonitoringDisabled: boolean
+  // Description to feed into the monitoring Toggle's `description` prop.
+  // Switches to a context-aware message when the group has locked monitoring off.
+  monitoringDescription: string
+}
+
+// Keeps the per-service "Enable Monitoring" toggle in sync with the parent
+// group's monitoring flag. The backend skips health checks for any service
+// inside a non-monitored group (see GetAllForMonitoring), so letting a user
+// flip the per-service flag on in that situation would just produce a stuck
+// "unknown" status.
+export function useGroupMonitoringLock({
+  groups,
+  selectedGroupId,
+  enableServiceGrouping,
+  monitoringEnabled,
+  setMonitoringEnabled,
+}: UseGroupMonitoringLockArgs): UseGroupMonitoringLockResult {
+  const selectedGroup = enableServiceGrouping
+    ? groups.find((g) => g.id === selectedGroupId)
+    : undefined
+  const groupMonitoringDisabled = selectedGroup?.monitoring_enabled === false
+
+  useEffect(() => {
+    if (groupMonitoringDisabled && monitoringEnabled) {
+      setMonitoringEnabled(false)
+    }
+  }, [groupMonitoringDisabled, monitoringEnabled, setMonitoringEnabled])
+
+  const monitoringDescription = groupMonitoringDisabled
+    ? `Monitoring is disabled for the "${selectedGroup?.name}" group, so services in it are never health-checked`
+    : DEFAULT_MONITORING_DESCRIPTION
+
+  return { selectedGroup, groupMonitoringDisabled, monitoringDescription }
+}

--- a/frontend/lib/monitoring.ts
+++ b/frontend/lib/monitoring.ts
@@ -18,6 +18,10 @@ export function buildGroupMonitoringMap(groups: Group[] | undefined | null): Gro
 // The backend health-checker enforces the same rule (see GetAllForMonitoring),
 // so a service with monitoring_enabled=true inside a non-monitored group sits
 // at status="unknown" forever — surface that as "not monitored" in the UI.
+//
+// If the service references a group_id not present in the map (e.g. groups
+// haven't loaded yet, or a race where the service arrived first), we default
+// to "monitored". The status will correct itself once the groups list is in.
 export function isServiceEffectivelyMonitored(
   service: Pick<Service, 'monitoring_enabled' | 'group_id'>,
   groupMonitoringMap?: GroupMonitoringMap | null

--- a/frontend/lib/monitoring.ts
+++ b/frontend/lib/monitoring.ts
@@ -1,0 +1,29 @@
+import type { Group, Service } from '@/types'
+
+export type GroupMonitoringMap = Map<string, boolean>
+
+export function buildGroupMonitoringMap(groups: Group[] | undefined | null): GroupMonitoringMap {
+  const map: GroupMonitoringMap = new Map()
+  if (!groups) return map
+  for (const group of groups) {
+    map.set(group.id, group.monitoring_enabled)
+  }
+  return map
+}
+
+// A service is effectively monitored only when:
+// - its own monitoring_enabled flag is true, AND
+// - it either has no group, or its group's monitoring_enabled is true.
+//
+// The backend health-checker enforces the same rule (see GetAllForMonitoring),
+// so a service with monitoring_enabled=true inside a non-monitored group sits
+// at status="unknown" forever — surface that as "not monitored" in the UI.
+export function isServiceEffectivelyMonitored(
+  service: Pick<Service, 'monitoring_enabled' | 'group_id'>,
+  groupMonitoringMap?: GroupMonitoringMap | null
+): boolean {
+  if (!service.monitoring_enabled) return false
+  if (!service.group_id) return true
+  if (!groupMonitoringMap) return true
+  return groupMonitoringMap.get(service.group_id) !== false
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -73,7 +73,7 @@ export interface ServiceUpdateRequest {
   icon_image_path?: string
   description?: string
   card_size?: CardSize
-  group_id?: string | null
+  group_id?: string
   monitoring_enabled?: boolean
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing service group when update omits group; sending an empty value now clears the group.

* **New Features**
  * Unified monitoring helpers that combine service- and group-level settings to determine monitoring.
  * Monitoring toggle in create/edit flows is disabled with contextual description when the selected group disallows monitoring.
  * UI now threads per-service monitored state to cards, lists, and drag-and-drop flows; drag operations clear group with an explicit empty value.

* **Tests**
  * Added regression and unit tests for group-preserve behavior and monitoring helpers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Turbootzz/Nimbus/pull/155)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->