### PR TITLE
Fix/144 156 orphan avatars and create redirect

### DIFF
--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -298,6 +298,9 @@ func (h *AuthHandler) DeleteAccount(c *fiber.Ctx) error {
 		})
 	}
 
+	// Run after the DB delete so we never orphan a row pointing at a missing file.
+	removeLocalAvatar(user.AvatarURL, "DeleteAccount")
+
 	c.Cookie(utils.ClearAuthCookie(h.cookieConfig))
 	return c.JSON(fiber.Map{
 		"message": "Account deleted successfully",

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -853,12 +854,12 @@ func TestAuthHandler_DeleteAccount(t *testing.T) {
 	})
 
 	t.Run("Removes local avatar file from disk", func(t *testing.T) {
-		tempDir := t.TempDir()
-		originalDir := AvatarUploadDir
-		AvatarUploadDir = tempDir
-		t.Cleanup(func() { AvatarUploadDir = originalDir })
-
-		avatarPath := tempDir + "/avatar.jpg"
+		// Integration check: DeleteAccount wires the helper through.
+		// Per-branch behaviour of removeLocalAvatar (nil, remote, traversal,
+		// missing file) is covered by TestRemoveLocalAvatar in
+		// avatar_cleanup_test.go.
+		dir := withTempAvatarDir(t)
+		avatarPath := filepath.Join(dir, "avatar.jpg")
 		if err := os.WriteFile(avatarPath, []byte("x"), 0o644); err != nil {
 			t.Fatalf("Failed to write fake avatar: %v", err)
 		}
@@ -895,40 +896,6 @@ func TestAuthHandler_DeleteAccount(t *testing.T) {
 
 		if _, err := os.Stat(avatarPath); !os.IsNotExist(err) {
 			t.Errorf("Avatar file should be removed from disk, got err=%v", err)
-		}
-	})
-
-	t.Run("Leaves remote avatar URLs alone", func(t *testing.T) {
-		// Regression guard: the helper must skip OAuth-style remote URLs without
-		// attempting any disk I/O.
-		userOAuth := &models.User{
-			ID:        "user-with-remote-avatar",
-			Email:     "remote-avatar@example.com",
-			Name:      "Remote Avatar",
-			Password:  &hashedPassword,
-			Role:      "user",
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		}
-		createUserDirectly(t, db, userOAuth)
-		remoteURL := "https://lh3.googleusercontent.com/a/example"
-		if err := userRepo.UpdateAvatar(userOAuth.ID, &remoteURL); err != nil {
-			t.Fatalf("Failed to set avatar URL: %v", err)
-		}
-
-		app := fiber.New()
-		app.Delete("/auth/me", func(c *fiber.Ctx) error {
-			c.Locals("user_id", userOAuth.ID)
-			return handler.DeleteAccount(c)
-		})
-
-		req := httptest.NewRequest(http.MethodDelete, "/auth/me", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("Failed to execute request: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
 		}
 	})
 }

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -851,4 +851,84 @@ func TestAuthHandler_DeleteAccount(t *testing.T) {
 			t.Errorf("Expected status %d, got %d", http.StatusNotFound, resp.StatusCode)
 		}
 	})
+
+	t.Run("Removes local avatar file from disk", func(t *testing.T) {
+		tempDir := t.TempDir()
+		originalDir := AvatarUploadDir
+		AvatarUploadDir = tempDir
+		t.Cleanup(func() { AvatarUploadDir = originalDir })
+
+		avatarPath := tempDir + "/avatar.jpg"
+		if err := os.WriteFile(avatarPath, []byte("x"), 0o644); err != nil {
+			t.Fatalf("Failed to write fake avatar: %v", err)
+		}
+
+		userWithAvatar := &models.User{
+			ID:        "user-with-local-avatar",
+			Email:     "local-avatar@example.com",
+			Name:      "Local Avatar",
+			Password:  &hashedPassword,
+			Role:      "user",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		createUserDirectly(t, db, userWithAvatar)
+		avatarURL := "/uploads/avatars/avatar.jpg"
+		if err := userRepo.UpdateAvatar(userWithAvatar.ID, &avatarURL); err != nil {
+			t.Fatalf("Failed to set avatar URL: %v", err)
+		}
+
+		app := fiber.New()
+		app.Delete("/auth/me", func(c *fiber.Ctx) error {
+			c.Locals("user_id", userWithAvatar.ID)
+			return handler.DeleteAccount(c)
+		})
+
+		req := httptest.NewRequest(http.MethodDelete, "/auth/me", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("Failed to execute request: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
+		}
+
+		if _, err := os.Stat(avatarPath); !os.IsNotExist(err) {
+			t.Errorf("Avatar file should be removed from disk, got err=%v", err)
+		}
+	})
+
+	t.Run("Leaves remote avatar URLs alone", func(t *testing.T) {
+		// Regression guard: the helper must skip OAuth-style remote URLs without
+		// attempting any disk I/O.
+		userOAuth := &models.User{
+			ID:        "user-with-remote-avatar",
+			Email:     "remote-avatar@example.com",
+			Name:      "Remote Avatar",
+			Password:  &hashedPassword,
+			Role:      "user",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		createUserDirectly(t, db, userOAuth)
+		remoteURL := "https://lh3.googleusercontent.com/a/example"
+		if err := userRepo.UpdateAvatar(userOAuth.ID, &remoteURL); err != nil {
+			t.Fatalf("Failed to set avatar URL: %v", err)
+		}
+
+		app := fiber.New()
+		app.Delete("/auth/me", func(c *fiber.Ctx) error {
+			c.Locals("user_id", userOAuth.ID)
+			return handler.DeleteAccount(c)
+		})
+
+		req := httptest.NewRequest(http.MethodDelete, "/auth/me", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("Failed to execute request: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
+		}
+	})
 }

--- a/backend/internal/handlers/avatar_cleanup.go
+++ b/backend/internal/handlers/avatar_cleanup.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// removeLocalAvatar deletes the on-disk avatar file referenced by avatarURL
+// when it lives under /uploads/avatars/. No-op for nil pointers, remote URLs
+// (OAuth providers), or files that are already gone. Errors are logged so
+// orphans show up in ops logs, but never returned — callers can't usefully
+// recover from a failed unlink.
+func removeLocalAvatar(avatarURL *string, caller string) {
+	if avatarURL == nil || !strings.HasPrefix(*avatarURL, "/uploads/avatars/") {
+		return
+	}
+	// filepath.Base strips any directory components an attacker might have
+	// smuggled into a stored URL.
+	filename := filepath.Base(strings.TrimPrefix(*avatarURL, "/uploads/avatars/"))
+	if filename == "." || filename == "/" || filename == "" {
+		return
+	}
+	path := filepath.Join(AvatarUploadDir, filename)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Printf("%s: failed to remove avatar %q: %v", caller, path, err)
+	}
+}

--- a/backend/internal/handlers/avatar_cleanup_test.go
+++ b/backend/internal/handlers/avatar_cleanup_test.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func ptr(s string) *string { return &s }
+
+// withTempAvatarDir swaps AvatarUploadDir for the duration of the test and
+// restores the original value via t.Cleanup. Returns the temp dir path.
+func withTempAvatarDir(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	original := AvatarUploadDir
+	AvatarUploadDir = tempDir
+	t.Cleanup(func() { AvatarUploadDir = original })
+	return tempDir
+}
+
+func TestRemoveLocalAvatar(t *testing.T) {
+	t.Run("removes a local avatar file", func(t *testing.T) {
+		dir := withTempAvatarDir(t)
+		path := filepath.Join(dir, "avatar.jpg")
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed file: %v", err)
+		}
+
+		removeLocalAvatar(ptr("/uploads/avatars/avatar.jpg"), "test")
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("file should be gone, stat err=%v", err)
+		}
+	})
+
+	t.Run("no-op for nil URL", func(t *testing.T) {
+		withTempAvatarDir(t)
+		// Just must not panic.
+		removeLocalAvatar(nil, "test")
+	})
+
+	t.Run("no-op for remote OAuth URL", func(t *testing.T) {
+		dir := withTempAvatarDir(t)
+		// Write a sentinel file in the avatars dir. If the helper wrongly
+		// derives a filename from a remote URL, this is the only thing it
+		// could plausibly hit.
+		sentinel := filepath.Join(dir, "sentinel")
+		if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed sentinel: %v", err)
+		}
+
+		removeLocalAvatar(ptr("https://lh3.googleusercontent.com/a/example"), "test")
+
+		if _, err := os.Stat(sentinel); err != nil {
+			t.Errorf("sentinel should be untouched: %v", err)
+		}
+	})
+
+	t.Run("no-op when the file is already gone", func(t *testing.T) {
+		withTempAvatarDir(t)
+		// File never existed — helper should swallow the not-exist error.
+		removeLocalAvatar(ptr("/uploads/avatars/missing.jpg"), "test")
+	})
+
+	t.Run("strips path traversal segments", func(t *testing.T) {
+		dir := withTempAvatarDir(t)
+		// An attacker-controlled URL ending in ../../etc/passwd should resolve
+		// to AvatarUploadDir/passwd via filepath.Base, never escape the dir.
+		target := filepath.Join(dir, "passwd")
+		if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed target: %v", err)
+		}
+		outside := filepath.Join(t.TempDir(), "outside")
+		if err := os.WriteFile(outside, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed outside: %v", err)
+		}
+
+		removeLocalAvatar(ptr("/uploads/avatars/../../etc/passwd"), "test")
+
+		if _, err := os.Stat(outside); err != nil {
+			t.Errorf("file outside avatar dir must not be touched: %v", err)
+		}
+		// The in-dir "passwd" file is fair game — Base("../../etc/passwd") == "passwd".
+		// We don't assert on its state; the point is that escape is prevented.
+	})
+
+	t.Run("ignores empty filename after prefix strip", func(t *testing.T) {
+		withTempAvatarDir(t)
+		// "/uploads/avatars/" with no filename — TrimPrefix yields "",
+		// filepath.Base("") yields ".", which the guard catches.
+		removeLocalAvatar(ptr("/uploads/avatars/"), "test")
+	})
+}

--- a/backend/internal/handlers/upload_handler.go
+++ b/backend/internal/handlers/upload_handler.go
@@ -19,13 +19,15 @@ const (
 	MaxUploadSize    = 512 * 1024      // 512KB - reasonable for icons
 	MaxAvatarSize    = 5 * 1024 * 1024 // 5MB for avatars
 	UploadDir        = "uploads/service-icons"
-	AvatarUploadDir  = "uploads/avatars"
 	AllowedMimeTypes = "image/jpeg,image/png,image/gif,image/webp"
 	// FaviconAllowedMimeTypes extends the upload set with .ico and SVG so server-fetched
 	// favicons can be stored in their original (often crispest) form. SVG is safe to
 	// serve via <img> because browsers disable scripts in that context.
 	FaviconAllowedMimeTypes = AllowedMimeTypes + ",image/x-icon,image/vnd.microsoft.icon,image/svg+xml"
 )
+
+// AvatarUploadDir is a var (not const) so tests can redirect uploads to t.TempDir().
+var AvatarUploadDir = "uploads/avatars"
 
 // errImageTooLarge / errImageInvalidType are returned by saveValidatedImage so
 // callers can map them to 400 responses instead of 500.
@@ -178,16 +180,10 @@ func (h *UploadHandler) UploadAvatar(c *fiber.Ctx) error {
 	}
 	defer src.Close()
 
-	// Delete old avatar (if any) before writing the new one. Warn rather than
-	// fail if the unlink errors — most likely "file already gone" — so we
-	// don't block the user, but ops can spot orphaned files in the log.
-	if user.AvatarURL != nil && strings.HasPrefix(*user.AvatarURL, "/uploads/avatars/") {
-		oldFilename := strings.TrimPrefix(*user.AvatarURL, "/uploads/avatars/")
-		oldPath := filepath.Join(AvatarUploadDir, oldFilename)
-		if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
-			log.Printf("UploadAvatar: failed to remove old avatar %q: %v", oldPath, err)
-		}
-	}
+	// Delete old avatar before writing the new one. The helper logs but never
+	// returns errors — most likely "file already gone" — so we don't block the
+	// user, but ops can spot true orphans in the log.
+	removeLocalAvatar(user.AvatarURL, "UploadAvatar")
 
 	filename, err := saveValidatedImage(src, AvatarUploadDir, MaxAvatarSize, AllowedMimeTypes)
 	if err != nil {

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -487,14 +487,14 @@ export default function DashboardPage() {
     setIsEditMode((prev) => !prev)
   }, [])
 
-  // Memoize add service href to avoid recalculating on every render
-  const addServiceHref = useMemo(
-    () =>
-      enableServiceGrouping && selectedGroupId
-        ? `/services/new?group=${selectedGroupId}`
-        : '/services/new',
-    [enableServiceGrouping, selectedGroupId]
-  )
+  // Memoize add service href to avoid recalculating on every render.
+  // `from=dashboard` tells /services/new where to redirect after create.
+  const addServiceHref = useMemo(() => {
+    const params = new URLSearchParams()
+    if (enableServiceGrouping && selectedGroupId) params.set('group', selectedGroupId)
+    params.set('from', 'dashboard')
+    return `/services/new?${params.toString()}`
+  }, [enableServiceGrouping, selectedGroupId])
 
   const handleGroupFormSubmit = async (data: {
     name?: string

--- a/frontend/app/(dashboard)/services/new/page.tsx
+++ b/frontend/app/(dashboard)/services/new/page.tsx
@@ -13,10 +13,15 @@ import type { IconType, Group } from '@/types'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useGroupMonitoringLock } from '@/hooks/useGroupMonitoringLock'
 
+// Whitelist of valid `from` values to prevent open-redirect via crafted URLs.
+const RETURN_PATHS: Record<string, string> = { dashboard: '/dashboard' }
+
 function NewServiceContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const preselectedGroupId = searchParams.get('group')
+  const returnHref = RETURN_PATHS[searchParams.get('from') ?? ''] ?? '/services'
+  const returnLabel = returnHref === '/dashboard' ? 'Dashboard' : 'Services'
   const { enableServiceGrouping } = useTheme()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
@@ -133,8 +138,7 @@ function NewServiceContent() {
       if (response.error) {
         setError(response.error.message)
       } else {
-        // Success - redirect to services list
-        router.push('/services')
+        router.push(returnHref)
       }
     } catch (error) {
       console.error('Failed to create service:', error)
@@ -159,11 +163,11 @@ function NewServiceContent() {
     <div className="mx-auto max-w-2xl">
       {/* Back button */}
       <Link
-        href="/services"
+        href={returnHref}
         className="text-text-secondary hover:text-text-primary mb-6 inline-flex items-center text-sm transition-colors"
       >
         <ArrowLeftIcon className="mr-2 h-4 w-4" />
-        Back to Services
+        Back to {returnLabel}
       </Link>
 
       {/* Page header */}
@@ -310,7 +314,7 @@ function NewServiceContent() {
             style={{ borderColor: 'var(--color-card-border)' }}
           >
             <Link
-              href="/services"
+              href={returnHref}
               className="hover:bg-card-border text-text-secondary hover:text-text-primary rounded-md px-4 py-2 text-sm font-medium transition-colors"
             >
               Cancel

--- a/frontend/app/(dashboard)/services/new/page.tsx
+++ b/frontend/app/(dashboard)/services/new/page.tsx
@@ -14,14 +14,18 @@ import { useTheme } from '@/contexts/ThemeContext'
 import { useGroupMonitoringLock } from '@/hooks/useGroupMonitoringLock'
 
 // Whitelist of valid `from` values to prevent open-redirect via crafted URLs.
-const RETURN_PATHS: Record<string, string> = { dashboard: '/dashboard' }
+// href and label live together so adding a target can't leave the back-link
+// pointing one place while the label says another.
+const RETURN_TARGETS: Record<string, { href: string; label: string }> = {
+  dashboard: { href: '/dashboard', label: 'Dashboard' },
+}
+const DEFAULT_RETURN = { href: '/services', label: 'Services' }
 
 function NewServiceContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const preselectedGroupId = searchParams.get('group')
-  const returnHref = RETURN_PATHS[searchParams.get('from') ?? ''] ?? '/services'
-  const returnLabel = returnHref === '/dashboard' ? 'Dashboard' : 'Services'
+  const returnTarget = RETURN_TARGETS[searchParams.get('from') ?? ''] ?? DEFAULT_RETURN
   const { enableServiceGrouping } = useTheme()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
@@ -138,7 +142,7 @@ function NewServiceContent() {
       if (response.error) {
         setError(response.error.message)
       } else {
-        router.push(returnHref)
+        router.push(returnTarget.href)
       }
     } catch (error) {
       console.error('Failed to create service:', error)
@@ -163,11 +167,11 @@ function NewServiceContent() {
     <div className="mx-auto max-w-2xl">
       {/* Back button */}
       <Link
-        href={returnHref}
+        href={returnTarget.href}
         className="text-text-secondary hover:text-text-primary mb-6 inline-flex items-center text-sm transition-colors"
       >
         <ArrowLeftIcon className="mr-2 h-4 w-4" />
-        Back to {returnLabel}
+        Back to {returnTarget.label}
       </Link>
 
       {/* Page header */}
@@ -314,7 +318,7 @@ function NewServiceContent() {
             style={{ borderColor: 'var(--color-card-border)' }}
           >
             <Link
-              href={returnHref}
+              href={returnTarget.href}
               className="hover:bg-card-border text-text-secondary hover:text-text-primary rounded-md px-4 py-2 text-sm font-medium transition-colors"
             >
               Cancel


### PR DESCRIPTION
Defer to issue #144 and #156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Avatar files are now properly cleaned up when users delete their accounts, preventing orphaned files.
  * Service creation flow now correctly returns to the previous page or dashboard context after completing the action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Turbootzz/Nimbus/pull/157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->