### PR TITLE
Feat/hero Nimbus cloud cta

### DIFF
--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -13,7 +13,14 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
         {/* Logo/Branding */}
         <div className="mb-8 flex flex-col items-center text-center">
           <div className="mb-2 flex items-center gap-3">
-            <Image src="/images/logo.png" alt="Nimbus Logo" width={48} height={48} priority />
+            <Image
+              src="/images/logo.png"
+              alt="Nimbus Logo"
+              width={272}
+              height={202}
+              style={{ width: 48, height: 'auto' }}
+              priority
+            />
             <h1 className="text-4xl font-bold" style={{ color: 'var(--color-text-primary)' }}>
               Nimbus
             </h1>

--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -1,5 +1,5 @@
 import ThemeToggle from '@/components/ThemeToggle'
-import Image from 'next/image'
+import NimbusLogo from '@/components/NimbusLogo'
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -13,14 +13,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
         {/* Logo/Branding */}
         <div className="mb-8 flex flex-col items-center text-center">
           <div className="mb-2 flex items-center gap-3">
-            <Image
-              src="/images/logo.png"
-              alt="Nimbus Logo"
-              width={272}
-              height={202}
-              style={{ width: 48, height: 'auto' }}
-              priority
-            />
+            <NimbusLogo size={48} priority />
             <h1 className="text-4xl font-bold" style={{ color: 'var(--color-text-primary)' }}>
               Nimbus
             </h1>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,7 +9,13 @@ import {
 } from '@heroicons/react/24/outline'
 
 const NimbusLogo = ({ size = 32 }: { size?: number }) => (
-  <Image src="/images/logo.png" alt="Nimbus" width={size} height={size} />
+  <Image
+    src="/images/logo.png"
+    alt="Nimbus"
+    width={272}
+    height={202}
+    style={{ width: size, height: 'auto' }}
+  />
 )
 
 const features = [
@@ -99,21 +105,31 @@ export default function LandingPage() {
               The open-source homelab dashboard, hosted for you. No Docker, no maintenance — just
               organize your services.
             </p>
-            <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <Link
-                href="/login"
-                className="group flex items-center gap-2 rounded-lg bg-sky-500 px-6 py-3 text-base font-medium text-white shadow-lg transition-all hover:bg-sky-600 hover:shadow-xl"
-              >
-                Launch demo
-                <ArrowRightIcon className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-              </Link>
+            <div className="mt-10 flex flex-col items-center justify-center gap-4">
+              <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+                <a
+                  href="https://nimbusapp.dev"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-center gap-2 rounded-lg bg-sky-500 px-6 py-3 text-base font-medium text-white shadow-lg transition-all hover:bg-sky-600 hover:shadow-xl"
+                >
+                  Try Nimbus Cloud
+                  <ArrowRightIcon className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                </a>
+                <Link
+                  href="/login"
+                  className="rounded-lg border border-gray-300 bg-white px-6 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                >
+                  Launch demo
+                </Link>
+              </div>
               <a
                 href="https://github.com/Turbootzz/Nimbus#-quick-start"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-lg border border-gray-300 bg-white px-6 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                className="text-sm text-gray-500 transition-colors hover:text-gray-700"
               >
-                Self-Host in 2 Minutes
+                or self-host in 2 minutes →
               </a>
             </div>
           </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,16 +7,7 @@ import {
   CpuChipIcon,
   ArrowRightIcon,
 } from '@heroicons/react/24/outline'
-
-const NimbusLogo = ({ size = 32 }: { size?: number }) => (
-  <Image
-    src="/images/logo.png"
-    alt="Nimbus"
-    width={272}
-    height={202}
-    style={{ width: size, height: 'auto' }}
-  />
-)
+import NimbusLogo from '@/components/NimbusLogo'
 
 const features = [
   {

--- a/frontend/components/NimbusLogo.tsx
+++ b/frontend/components/NimbusLogo.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image'
+
+// Brand logo. The source image is 272x202; `size` sets the rendered width and
+// the height scales automatically to preserve the aspect ratio.
+export default function NimbusLogo({
+  size = 32,
+  priority = false,
+}: {
+  size?: number
+  priority?: boolean
+}) {
+  return (
+    <Image
+      src="/images/logo.png"
+      alt="Nimbus"
+      width={272}
+      height={202}
+      style={{ width: size, height: 'auto' }}
+      priority={priority}
+    />
+  )
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -212,7 +212,13 @@ export default function Sidebar({
           <div
             className={`border-sidebar-border flex h-16 shrink-0 items-center border-b ${isDesktopCollapsed ? 'justify-center px-3' : 'px-6'}`}
           >
-            <Image src="/images/logo.png" alt="Nimbus Logo" width={30} height={30} />
+            <Image
+              src="/images/logo.png"
+              alt="Nimbus Logo"
+              width={272}
+              height={202}
+              style={{ width: 30, height: 'auto' }}
+            />
             <span
               className={`text-text-primary overflow-hidden text-xl font-semibold whitespace-nowrap transition-all duration-300 ${
                 isDesktopCollapsed
@@ -270,7 +276,13 @@ export default function Sidebar({
           {/* Logo and close button */}
           <div className="border-sidebar-border flex h-16 items-center justify-between border-b px-6">
             <div className="flex items-center">
-              <Image src="/images/logo.png" alt="Nimbus Logo" width={32} height={32} />
+              <Image
+                src="/images/logo.png"
+                alt="Nimbus Logo"
+                width={272}
+                height={202}
+                style={{ width: 32, height: 'auto' }}
+              />
               <span className="text-text-primary ml-2 text-xl font-semibold">Nimbus</span>
             </div>
             <button

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useMemo, useCallback } from 'react'
 import Link from 'next/link'
-import Image from 'next/image'
+import NimbusLogo from '@/components/NimbusLogo'
 import { usePathname, useRouter } from 'next/navigation'
 import {
   HomeIcon,
@@ -212,13 +212,7 @@ export default function Sidebar({
           <div
             className={`border-sidebar-border flex h-16 shrink-0 items-center border-b ${isDesktopCollapsed ? 'justify-center px-3' : 'px-6'}`}
           >
-            <Image
-              src="/images/logo.png"
-              alt="Nimbus Logo"
-              width={272}
-              height={202}
-              style={{ width: 30, height: 'auto' }}
-            />
+            <NimbusLogo size={30} />
             <span
               className={`text-text-primary overflow-hidden text-xl font-semibold whitespace-nowrap transition-all duration-300 ${
                 isDesktopCollapsed
@@ -276,13 +270,7 @@ export default function Sidebar({
           {/* Logo and close button */}
           <div className="border-sidebar-border flex h-16 items-center justify-between border-b px-6">
             <div className="flex items-center">
-              <Image
-                src="/images/logo.png"
-                alt="Nimbus Logo"
-                width={272}
-                height={202}
-                style={{ width: 32, height: 'auto' }}
-              />
+              <NimbusLogo size={32} />
               <span className="text-text-primary ml-2 text-xl font-semibold">Nimbus</span>
             </div>
             <button


### PR DESCRIPTION
Add button for Nimbus Cloud on landing page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Nimbus logo component
  * Added "Try Nimbus Cloud" button linking to cloud offering

* **UI/UX Improvements**
  * Reorganized hero section call-to-action layout with updated button arrangement
  * Refreshed and standardized logo display across the app (header, sidebar, auth)
  * Restructured self-hosting option as a separate link
<!-- end of auto-generated comment: release notes by coderabbit.ai -->