### PR TITLE
feat: add generic OIDC provider (Keycloak, Authentik, Dex, etc.)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,14 @@
 # DISCORD_CLIENT_SECRET=
 # DISCORD_REDIRECT_URL=http://localhost:8080/api/v1/auth/oauth/discord/callback
 
+# Generic OIDC (Keycloak, Authentik, Dex, Okta, etc.)
+# Set OIDC_ISSUER_URL to your provider's issuer base URL.
+# Endpoints are discovered automatically from {issuer}/.well-known/openid-configuration.
+# OIDC_ISSUER_URL=https://auth.example.com/realms/master
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_REDIRECT_URL=http://localhost:8080/api/v1/auth/oauth/oidc/callback
+
 # SMTP Configuration (for password reset emails)
 # Can also be configured via Admin Settings UI
 # Note: SMTP credentials set via the Admin UI are stored unencrypted in the database.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -98,11 +98,12 @@ func main() {
 	googleConfig := config.GetGoogleOAuthConfig()
 	githubConfig := config.GetGitHubOAuthConfig()
 	discordConfig := config.GetDiscordOAuthConfig()
+	oidcConfig := config.GetOIDCConfig()
 	oauthStateSecret := os.Getenv("OAUTH_STATE_SECRET")
 	if oauthStateSecret == "" {
 		oauthStateSecret = os.Getenv("JWT_SECRET") // Fallback to JWT_SECRET
 	}
-	oauthService := services.NewOAuthService(googleConfig, githubConfig, discordConfig, oauthStateSecret)
+	oauthService := services.NewOAuthService(googleConfig, githubConfig, discordConfig, oidcConfig, oauthStateSecret)
 
 	// Initialize notification service
 	notificationService := services.NewNotificationService(webhookRepo, serviceRepo)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -168,3 +168,15 @@ func GetDiscordOAuthConfig() models.OAuthConfig {
 		RedirectURL:  os.Getenv("DISCORD_REDIRECT_URL"),
 	}
 }
+
+// GetOIDCConfig returns the generic OIDC configuration.
+// Set OIDC_ISSUER_URL to the provider's issuer URL (e.g. https://auth.example.com/realms/master).
+// Endpoints are discovered automatically from {issuer}/.well-known/openid-configuration.
+func GetOIDCConfig() models.OAuthConfig {
+	return models.OAuthConfig{
+		ClientID:     os.Getenv("OIDC_CLIENT_ID"),
+		ClientSecret: os.Getenv("OIDC_CLIENT_SECRET"),
+		RedirectURL:  os.Getenv("OIDC_REDIRECT_URL"),
+		IssuerURL:    os.Getenv("OIDC_ISSUER_URL"),
+	}
+}

--- a/backend/internal/handlers/oauth_handler.go
+++ b/backend/internal/handlers/oauth_handler.go
@@ -298,6 +298,11 @@ func (h *OAuthHandler) GetProviderStatus(c *fiber.Ctx) error {
 			"enabled":   h.oauthService.IsProviderConfigured(models.ProviderDiscord),
 			"configure": h.oauthService.IsProviderConfigured(models.ProviderDiscord),
 		},
+		{
+			"name":      "oidc",
+			"enabled":   h.oauthService.IsProviderConfigured(models.ProviderOIDC),
+			"configure": h.oauthService.IsProviderConfigured(models.ProviderOIDC),
+		},
 	}
 
 	return c.JSON(fiber.Map{

--- a/backend/internal/models/oauth.go
+++ b/backend/internal/models/oauth.go
@@ -10,12 +10,13 @@ const (
 	ProviderGoogle  OAuthProvider = "google"
 	ProviderGitHub  OAuthProvider = "github"
 	ProviderDiscord OAuthProvider = "discord"
+	ProviderOIDC    OAuthProvider = "oidc"
 )
 
 // IsValid checks if the provider is supported
 func (p OAuthProvider) IsValid() bool {
 	switch p {
-	case ProviderLocal, ProviderGoogle, ProviderGitHub, ProviderDiscord:
+	case ProviderLocal, ProviderGoogle, ProviderGitHub, ProviderDiscord, ProviderOIDC:
 		return true
 	default:
 		return false
@@ -28,6 +29,7 @@ type OAuthConfig struct {
 	ClientSecret string
 	RedirectURL  string
 	Scopes       []string
+	IssuerURL    string // OIDC only: used for endpoint discovery
 }
 
 // OAuthUserInfo represents user information from OAuth providers

--- a/backend/internal/services/oauth_oidc_test.go
+++ b/backend/internal/services/oauth_oidc_test.go
@@ -155,6 +155,12 @@ func oidcService(userInfoURL string) *OAuthService {
 func userInfoServer(t *testing.T, status int, body string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Assert the userinfo-call contract, not just response parsing: the
+		// request must be a GET carrying the access token as a bearer header.
+		// (assert, not require: a require failure would Goexit this server
+		// goroutine rather than the test.)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
@@ -171,7 +177,7 @@ func TestFetchOIDCUserInfo_Success(t *testing.T) {
 	}`)
 	defer srv.Close()
 
-	info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+	info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "test-token"})
 	require.NoError(t, err)
 	assert.Equal(t, "user-123", info.ProviderID)
 	assert.Equal(t, "ada@example.com", info.Email)
@@ -203,7 +209,7 @@ func TestFetchOIDCUserInfo_NameFallbacks(t *testing.T) {
 			srv := userInfoServer(t, http.StatusOK, tt.body)
 			defer srv.Close()
 
-			info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+			info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "test-token"})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantName, info.Name)
 		})
@@ -228,7 +234,7 @@ func TestFetchOIDCUserInfo_EmailVerifiedFormats(t *testing.T) {
 			srv := userInfoServer(t, http.StatusOK, tt.body)
 			defer srv.Close()
 
-			info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+			info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "test-token"})
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, info.EmailVerified)
 		})
@@ -258,7 +264,7 @@ func TestFetchOIDCUserInfo_MissingRequiredClaims(t *testing.T) {
 			srv := userInfoServer(t, http.StatusOK, tt.body)
 			defer srv.Close()
 
-			_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+			_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "test-token"})
 			require.Error(t, err)
 			assert.ErrorIs(t, err, ErrFetchUserInfo)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -270,7 +276,7 @@ func TestFetchOIDCUserInfo_Non200(t *testing.T) {
 	srv := userInfoServer(t, http.StatusUnauthorized, `{"error":"invalid_token"}`)
 	defer srv.Close()
 
-	_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+	_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "test-token"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrFetchUserInfo)
 	assert.Contains(t, err.Error(), "status 401")
@@ -280,7 +286,7 @@ func TestFetchOIDCUserInfo_InvalidJSON(t *testing.T) {
 	srv := userInfoServer(t, http.StatusOK, `not json`)
 	defer srv.Close()
 
-	_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+	_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "test-token"})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrFetchUserInfo))
 }

--- a/backend/internal/services/oauth_oidc_test.go
+++ b/backend/internal/services/oauth_oidc_test.go
@@ -1,0 +1,286 @@
+package services
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nimbus/backend/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// discoveryServer spins up a test server that serves an OIDC discovery
+// document at /.well-known/openid-configuration. The body is rendered by the
+// caller-provided function so each test can control issuer/endpoints; the
+// {{ISSUER}} placeholder is replaced with the server's own URL.
+func discoveryServer(t *testing.T, status int, body func(issuer string) string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(nil)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body(srv.URL)))
+	})
+	srv.Config.Handler = mux
+	return srv
+}
+
+func TestDiscoverOIDCEndpoints_Success(t *testing.T) {
+	srv := discoveryServer(t, http.StatusOK, func(issuer string) string {
+		return `{
+			"issuer": "` + issuer + `",
+			"authorization_endpoint": "` + issuer + `/auth",
+			"token_endpoint": "` + issuer + `/token",
+			"userinfo_endpoint": "` + issuer + `/userinfo"
+		}`
+	})
+	defer srv.Close()
+
+	endpoint, userInfoURL, err := discoverOIDCEndpoints(srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/auth", endpoint.AuthURL)
+	assert.Equal(t, srv.URL+"/token", endpoint.TokenURL)
+	assert.Equal(t, srv.URL+"/userinfo", userInfoURL)
+}
+
+func TestDiscoverOIDCEndpoints_TrailingSlashIssuerStillMatches(t *testing.T) {
+	srv := discoveryServer(t, http.StatusOK, func(issuer string) string {
+		// Provider advertises the issuer with a trailing slash; our config has none.
+		return `{
+			"issuer": "` + issuer + `/",
+			"authorization_endpoint": "` + issuer + `/auth",
+			"token_endpoint": "` + issuer + `/token",
+			"userinfo_endpoint": "` + issuer + `/userinfo"
+		}`
+	})
+	defer srv.Close()
+
+	_, _, err := discoverOIDCEndpoints(srv.URL)
+	assert.NoError(t, err)
+}
+
+func TestDiscoverOIDCEndpoints_IssuerMismatch(t *testing.T) {
+	srv := discoveryServer(t, http.StatusOK, func(issuer string) string {
+		return `{
+			"issuer": "https://evil.example.com",
+			"authorization_endpoint": "` + issuer + `/auth",
+			"token_endpoint": "` + issuer + `/token",
+			"userinfo_endpoint": "` + issuer + `/userinfo"
+		}`
+	})
+	defer srv.Close()
+
+	_, _, err := discoverOIDCEndpoints(srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer mismatch")
+}
+
+func TestDiscoverOIDCEndpoints_MissingEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  func(issuer string) string
+	}{
+		{
+			name: "missing authorization_endpoint",
+			doc: func(issuer string) string {
+				return `{"issuer":"` + issuer + `","token_endpoint":"` + issuer + `/token","userinfo_endpoint":"` + issuer + `/userinfo"}`
+			},
+		},
+		{
+			name: "missing token_endpoint",
+			doc: func(issuer string) string {
+				return `{"issuer":"` + issuer + `","authorization_endpoint":"` + issuer + `/auth","userinfo_endpoint":"` + issuer + `/userinfo"}`
+			},
+		},
+		{
+			name: "missing userinfo_endpoint",
+			doc: func(issuer string) string {
+				return `{"issuer":"` + issuer + `","authorization_endpoint":"` + issuer + `/auth","token_endpoint":"` + issuer + `/token"}`
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := discoveryServer(t, http.StatusOK, tt.doc)
+			defer srv.Close()
+
+			_, _, err := discoverOIDCEndpoints(srv.URL)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "missing required endpoints")
+		})
+	}
+}
+
+func TestDiscoverOIDCEndpoints_Non200(t *testing.T) {
+	srv := discoveryServer(t, http.StatusNotFound, func(issuer string) string { return `{}` })
+	defer srv.Close()
+
+	_, _, err := discoverOIDCEndpoints(srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 404")
+}
+
+func TestDiscoverOIDCEndpoints_InvalidJSON(t *testing.T) {
+	srv := discoveryServer(t, http.StatusOK, func(issuer string) string { return `not json` })
+	defer srv.Close()
+
+	_, _, err := discoverOIDCEndpoints(srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse discovery document")
+}
+
+func TestDiscoverOIDCEndpoints_UnreachableIssuer(t *testing.T) {
+	// Port 0 on the discard host is never listening, so the request fails.
+	_, _, err := discoverOIDCEndpoints("http://127.0.0.1:0")
+	assert.Error(t, err)
+}
+
+// oidcService builds an OAuthService wired to a userinfo endpoint for testing
+// fetchOIDCUserInfo without going through discovery.
+func oidcService(userInfoURL string) *OAuthService {
+	return &OAuthService{
+		configs: map[models.OAuthProvider]*oauth2.Config{
+			models.ProviderOIDC: {},
+		},
+		oidcUserInfoURL: userInfoURL,
+		stateSecret:     "test-secret-key-for-testing-32ch",
+	}
+}
+
+func userInfoServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestFetchOIDCUserInfo_Success(t *testing.T) {
+	srv := userInfoServer(t, http.StatusOK, `{
+		"sub": "user-123",
+		"name": "Ada Lovelace",
+		"email": "ada@example.com",
+		"picture": "https://example.com/ada.png",
+		"email_verified": true
+	}`)
+	defer srv.Close()
+
+	info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", info.ProviderID)
+	assert.Equal(t, "ada@example.com", info.Email)
+	assert.Equal(t, "Ada Lovelace", info.Name)
+	assert.Equal(t, "https://example.com/ada.png", info.AvatarURL)
+	assert.True(t, info.EmailVerified)
+}
+
+func TestFetchOIDCUserInfo_NameFallbacks(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantName string
+	}{
+		{
+			name:     "falls back to given_name + family_name when name is absent",
+			body:     `{"sub":"s","email":"u@example.com","given_name":"Grace","family_name":"Hopper"}`,
+			wantName: "Grace Hopper",
+		},
+		{
+			name:     "falls back to email when no name claims are present",
+			body:     `{"sub":"s","email":"u@example.com"}`,
+			wantName: "u@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := userInfoServer(t, http.StatusOK, tt.body)
+			defer srv.Close()
+
+			info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, info.Name)
+		})
+	}
+}
+
+func TestFetchOIDCUserInfo_EmailVerifiedFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "bool true", body: `{"sub":"s","email":"u@e.com","email_verified":true}`, want: true},
+		{name: "bool false", body: `{"sub":"s","email":"u@e.com","email_verified":false}`, want: false},
+		{name: "string true (Keycloak/Authentik)", body: `{"sub":"s","email":"u@e.com","email_verified":"true"}`, want: true},
+		{name: "string false", body: `{"sub":"s","email":"u@e.com","email_verified":"false"}`, want: false},
+		{name: "absent", body: `{"sub":"s","email":"u@e.com"}`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := userInfoServer(t, http.StatusOK, tt.body)
+			defer srv.Close()
+
+			info, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, info.EmailVerified)
+		})
+	}
+}
+
+func TestFetchOIDCUserInfo_MissingRequiredClaims(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "missing sub",
+			body:    `{"email":"u@example.com"}`,
+			wantErr: "missing subject claim",
+		},
+		{
+			name:    "missing email",
+			body:    `{"sub":"user-123"}`,
+			wantErr: "missing email claim",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := userInfoServer(t, http.StatusOK, tt.body)
+			defer srv.Close()
+
+			_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrFetchUserInfo)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestFetchOIDCUserInfo_Non200(t *testing.T) {
+	srv := userInfoServer(t, http.StatusUnauthorized, `{"error":"invalid_token"}`)
+	defer srv.Close()
+
+	_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFetchUserInfo)
+	assert.Contains(t, err.Error(), "status 401")
+}
+
+func TestFetchOIDCUserInfo_InvalidJSON(t *testing.T) {
+	srv := userInfoServer(t, http.StatusOK, `not json`)
+	defer srv.Close()
+
+	_, err := oidcService(srv.URL).fetchOIDCUserInfo(t.Context(), &oauth2.Token{AccessToken: "x"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrFetchUserInfo))
+}

--- a/backend/internal/services/oauth_service.go
+++ b/backend/internal/services/oauth_service.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -28,9 +29,25 @@ var (
 
 // OAuthService handles OAuth authentication flows
 type OAuthService struct {
+	mu              sync.RWMutex // guards configs and oidcUserInfoURL (OIDC is enabled asynchronously)
 	configs         map[models.OAuthProvider]*oauth2.Config
-	oidcUserInfoURL string // discovered at startup for the OIDC provider
+	oidcUserInfoURL string // discovered asynchronously for the OIDC provider
 	stateSecret     string
+}
+
+// config returns the oauth2 config for a provider in a concurrency-safe way.
+func (s *OAuthService) config(provider models.OAuthProvider) (*oauth2.Config, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.configs[provider]
+	return c, ok
+}
+
+// oidcUserInfoEndpoint returns the discovered OIDC userinfo URL.
+func (s *OAuthService) oidcUserInfoEndpoint() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.oidcUserInfoURL
 }
 
 // NewOAuthService creates a new OAuth service
@@ -85,23 +102,38 @@ func NewOAuthService(
 		}
 	}
 
-	// Configure generic OIDC — discover endpoints from the issuer URL
+	// Configure generic OIDC — discover endpoints from the issuer URL.
+	// Discovery hits a remote server, so run it in the background to avoid
+	// blocking server startup on a slow or unreachable issuer.
 	if oidcConfig.ClientID != "" && oidcConfig.IssuerURL != "" {
-		if endpoint, userInfoURL, err := discoverOIDCEndpoints(oidcConfig.IssuerURL); err != nil {
-			log.Printf("OIDC provider disabled: failed to discover endpoints for %s: %v", oidcConfig.IssuerURL, err)
-		} else {
-			service.configs[models.ProviderOIDC] = &oauth2.Config{
-				ClientID:     oidcConfig.ClientID,
-				ClientSecret: oidcConfig.ClientSecret,
-				RedirectURL:  oidcConfig.RedirectURL,
-				Scopes:       []string{"openid", "profile", "email"},
-				Endpoint:     endpoint,
-			}
-			service.oidcUserInfoURL = userInfoURL
-		}
+		go service.initOIDC(oidcConfig)
 	}
 
 	return service
+}
+
+// initOIDC discovers the OIDC provider's endpoints and enables the provider
+// once discovery succeeds. It runs in the background so a slow or unreachable
+// issuer never blocks server startup; the provider simply stays disabled until
+// (and unless) discovery completes.
+func (s *OAuthService) initOIDC(oidcConfig models.OAuthConfig) {
+	endpoint, userInfoURL, err := discoverOIDCEndpoints(oidcConfig.IssuerURL)
+	if err != nil {
+		log.Printf("OIDC provider disabled: failed to discover endpoints for %s: %v", oidcConfig.IssuerURL, err)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.configs[models.ProviderOIDC] = &oauth2.Config{
+		ClientID:     oidcConfig.ClientID,
+		ClientSecret: oidcConfig.ClientSecret,
+		RedirectURL:  oidcConfig.RedirectURL,
+		Scopes:       []string{"openid", "profile", "email"},
+		Endpoint:     endpoint,
+	}
+	s.oidcUserInfoURL = userInfoURL
+	log.Printf("OIDC provider enabled (issuer=%s)", oidcConfig.IssuerURL)
 }
 
 // discoverOIDCEndpoints fetches the provider's discovery document and returns
@@ -133,6 +165,7 @@ func discoverOIDCEndpoints(issuerURL string) (oauth2.Endpoint, string, error) {
 	}
 
 	var doc struct {
+		Issuer                string `json:"issuer"`
 		AuthorizationEndpoint string `json:"authorization_endpoint"`
 		TokenEndpoint         string `json:"token_endpoint"`
 		UserinfoEndpoint      string `json:"userinfo_endpoint"`
@@ -141,7 +174,13 @@ func discoverOIDCEndpoints(issuerURL string) (oauth2.Endpoint, string, error) {
 		return oauth2.Endpoint{}, "", fmt.Errorf("parse discovery document: %w", err)
 	}
 
-	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
+	// Ensure the document describes the issuer we asked for; a redirect or
+	// misconfigured endpoint could otherwise hand us another IdP's endpoints.
+	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(issuerURL, "/") {
+		return oauth2.Endpoint{}, "", fmt.Errorf("discovery document issuer mismatch: got %q, expected %q", doc.Issuer, issuerURL)
+	}
+
+	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" || doc.UserinfoEndpoint == "" {
 		return oauth2.Endpoint{}, "", fmt.Errorf("discovery document missing required endpoints")
 	}
 
@@ -153,7 +192,7 @@ func discoverOIDCEndpoints(issuerURL string) (oauth2.Endpoint, string, error) {
 
 // GetAuthURL generates the OAuth authorization URL with state token
 func (s *OAuthService) GetAuthURL(provider models.OAuthProvider, redirectTo string, rememberMe bool) (string, error) {
-	config, ok := s.configs[provider]
+	config, ok := s.config(provider)
 	if !ok {
 		return "", fmt.Errorf("%w: %s", ErrInvalidProvider, provider)
 	}
@@ -177,7 +216,7 @@ func (s *OAuthService) ExchangeCode(ctx context.Context, provider models.OAuthPr
 	}
 
 	// Get OAuth config for provider
-	config, ok := s.configs[provider]
+	config, ok := s.config(provider)
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidProvider, provider)
 	}
@@ -288,7 +327,8 @@ func (s *OAuthService) fetchUserInfo(ctx context.Context, provider models.OAuthP
 
 // fetchGoogleUserInfo fetches user info from Google
 func (s *OAuthService) fetchGoogleUserInfo(ctx context.Context, token *oauth2.Token) (*models.OAuthUserInfo, error) {
-	client := s.configs[models.ProviderGoogle].Client(ctx, token)
+	cfg, _ := s.config(models.ProviderGoogle)
+	client := cfg.Client(ctx, token)
 	resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
@@ -327,7 +367,8 @@ func (s *OAuthService) fetchGoogleUserInfo(ctx context.Context, token *oauth2.To
 
 // fetchGitHubUserInfo fetches user info from GitHub
 func (s *OAuthService) fetchGitHubUserInfo(ctx context.Context, token *oauth2.Token) (*models.OAuthUserInfo, error) {
-	client := s.configs[models.ProviderGitHub].Client(ctx, token)
+	cfg, _ := s.config(models.ProviderGitHub)
+	client := cfg.Client(ctx, token)
 
 	// Fetch user profile
 	resp, err := client.Get("https://api.github.com/user")
@@ -426,7 +467,8 @@ func (s *OAuthService) fetchGitHubEmail(client *http.Client) (string, error) {
 
 // fetchDiscordUserInfo fetches user info from Discord
 func (s *OAuthService) fetchDiscordUserInfo(ctx context.Context, token *oauth2.Token) (*models.OAuthUserInfo, error) {
-	client := s.configs[models.ProviderDiscord].Client(ctx, token)
+	cfg, _ := s.config(models.ProviderDiscord)
+	client := cfg.Client(ctx, token)
 	resp, err := client.Get("https://discord.com/api/users/@me")
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
@@ -478,10 +520,15 @@ func (s *OAuthService) fetchDiscordUserInfo(ctx context.Context, token *oauth2.T
 }
 
 // fetchOIDCUserInfo fetches user info from a generic OIDC provider's userinfo endpoint.
-// The endpoint URL is discovered at startup from the issuer's discovery document.
+// The endpoint URL is discovered from the issuer's discovery document during startup init.
 func (s *OAuthService) fetchOIDCUserInfo(ctx context.Context, token *oauth2.Token) (*models.OAuthUserInfo, error) {
-	client := s.configs[models.ProviderOIDC].Client(ctx, token)
-	resp, err := client.Get(s.oidcUserInfoURL)
+	cfg, _ := s.config(models.ProviderOIDC)
+	client := cfg.Client(ctx, token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.oidcUserInfoEndpoint(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
 	}
@@ -507,6 +554,12 @@ func (s *OAuthService) fetchOIDCUserInfo(ctx context.Context, token *oauth2.Toke
 	}
 	if err := json.Unmarshal(body, &u); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
+	}
+	if u.Sub == "" {
+		return nil, fmt.Errorf("%w: missing subject claim", ErrFetchUserInfo)
+	}
+	if u.Email == "" {
+		return nil, fmt.Errorf("%w: missing email claim", ErrFetchUserInfo)
 	}
 
 	name := u.Name
@@ -536,6 +589,6 @@ func (s *OAuthService) fetchOIDCUserInfo(ctx context.Context, token *oauth2.Toke
 
 // IsProviderConfigured checks if a provider is configured and available
 func (s *OAuthService) IsProviderConfigured(provider models.OAuthProvider) bool {
-	_, ok := s.configs[provider]
+	_, ok := s.config(provider)
 	return ok
 }

--- a/backend/internal/services/oauth_service.go
+++ b/backend/internal/services/oauth_service.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -26,8 +28,9 @@ var (
 
 // OAuthService handles OAuth authentication flows
 type OAuthService struct {
-	configs     map[models.OAuthProvider]*oauth2.Config
-	stateSecret string
+	configs         map[models.OAuthProvider]*oauth2.Config
+	oidcUserInfoURL string // discovered at startup for the OIDC provider
+	stateSecret     string
 }
 
 // NewOAuthService creates a new OAuth service
@@ -35,6 +38,7 @@ func NewOAuthService(
 	googleConfig models.OAuthConfig,
 	githubConfig models.OAuthConfig,
 	discordConfig models.OAuthConfig,
+	oidcConfig models.OAuthConfig,
 	stateSecret string,
 ) *OAuthService {
 	service := &OAuthService{
@@ -81,7 +85,70 @@ func NewOAuthService(
 		}
 	}
 
+	// Configure generic OIDC — discover endpoints from the issuer URL
+	if oidcConfig.ClientID != "" && oidcConfig.IssuerURL != "" {
+		if endpoint, userInfoURL, err := discoverOIDCEndpoints(oidcConfig.IssuerURL); err != nil {
+			log.Printf("OIDC provider disabled: failed to discover endpoints for %s: %v", oidcConfig.IssuerURL, err)
+		} else {
+			service.configs[models.ProviderOIDC] = &oauth2.Config{
+				ClientID:     oidcConfig.ClientID,
+				ClientSecret: oidcConfig.ClientSecret,
+				RedirectURL:  oidcConfig.RedirectURL,
+				Scopes:       []string{"openid", "profile", "email"},
+				Endpoint:     endpoint,
+			}
+			service.oidcUserInfoURL = userInfoURL
+		}
+	}
+
 	return service
+}
+
+// discoverOIDCEndpoints fetches the provider's discovery document and returns
+// the oauth2.Endpoint and userinfo URL.
+func discoverOIDCEndpoints(issuerURL string) (oauth2.Endpoint, string, error) {
+	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("fetch discovery document: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return oauth2.Endpoint{}, "", fmt.Errorf("discovery document returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("read discovery document: %w", err)
+	}
+
+	var doc struct {
+		AuthorizationEndpoint string `json:"authorization_endpoint"`
+		TokenEndpoint         string `json:"token_endpoint"`
+		UserinfoEndpoint      string `json:"userinfo_endpoint"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("parse discovery document: %w", err)
+	}
+
+	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
+		return oauth2.Endpoint{}, "", fmt.Errorf("discovery document missing required endpoints")
+	}
+
+	return oauth2.Endpoint{
+		AuthURL:  doc.AuthorizationEndpoint,
+		TokenURL: doc.TokenEndpoint,
+	}, doc.UserinfoEndpoint, nil
 }
 
 // GetAuthURL generates the OAuth authorization URL with state token
@@ -212,6 +279,8 @@ func (s *OAuthService) fetchUserInfo(ctx context.Context, provider models.OAuthP
 		return s.fetchGitHubUserInfo(ctx, token)
 	case models.ProviderDiscord:
 		return s.fetchDiscordUserInfo(ctx, token)
+	case models.ProviderOIDC:
+		return s.fetchOIDCUserInfo(ctx, token)
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrInvalidProvider, provider)
 	}
@@ -405,6 +474,63 @@ func (s *OAuthService) fetchDiscordUserInfo(ctx context.Context, token *oauth2.T
 		Name:          name,
 		AvatarURL:     avatarURL,
 		EmailVerified: discordUser.Verified,
+	}, nil
+}
+
+// fetchOIDCUserInfo fetches user info from a generic OIDC provider's userinfo endpoint.
+// The endpoint URL is discovered at startup from the issuer's discovery document.
+func (s *OAuthService) fetchOIDCUserInfo(ctx context.Context, token *oauth2.Token) (*models.OAuthUserInfo, error) {
+	client := s.configs[models.ProviderOIDC].Client(ctx, token)
+	resp, err := client.Get(s.oidcUserInfoURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: status %d", ErrFetchUserInfo, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
+	}
+
+	var u struct {
+		Sub           string      `json:"sub"`
+		Name          string      `json:"name"`
+		GivenName     string      `json:"given_name"`
+		FamilyName    string      `json:"family_name"`
+		Email         string      `json:"email"`
+		Picture       string      `json:"picture"`
+		EmailVerified interface{} `json:"email_verified"` // bool or string depending on provider
+	}
+	if err := json.Unmarshal(body, &u); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchUserInfo, err)
+	}
+
+	name := u.Name
+	if name == "" {
+		name = strings.TrimSpace(u.GivenName + " " + u.FamilyName)
+	}
+	if name == "" {
+		name = u.Email
+	}
+
+	emailVerified := false
+	switch v := u.EmailVerified.(type) {
+	case bool:
+		emailVerified = v
+	case string:
+		emailVerified = v == "true"
+	}
+
+	return &models.OAuthUserInfo{
+		ProviderID:    u.Sub,
+		Email:         u.Email,
+		Name:          name,
+		AvatarURL:     u.Picture,
+		EmailVerified: emailVerified,
 	}, nil
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       DB_HOST: db
       # Public URL for password reset emails and OAuth redirects:
       # FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+      # Generic OIDC (Keycloak, Authentik, Dex, etc.):
+      # OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-}
+      # OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      # OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      # OIDC_REDIRECT_URL: ${OIDC_REDIRECT_URL:-}
       # Optional overrides:
       # DB_PORT: 5432
       # DB_USER: nimbus

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -291,6 +291,9 @@ function LoginForm() {
             {oauthProviders.includes('discord') && (
               <OAuthButton provider="discord" redirectTo="/dashboard" rememberMe={rememberMe} />
             )}
+            {oauthProviders.includes('oidc') && (
+              <OAuthButton provider="oidc" redirectTo="/dashboard" rememberMe={rememberMe} />
+            )}
           </div>
         </>
       )}

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -9,6 +9,7 @@ import DangerZoneSection from '@/components/DangerZoneSection'
 import GoogleIcon from '@/components/icons/GoogleIcon'
 import GitHubIcon from '@/components/icons/GitHubIcon'
 import DiscordIcon from '@/components/icons/DiscordIcon'
+import OIDCIcon from '@/components/icons/OIDCIcon'
 
 export default function ProfilePage() {
   const [user, setUser] = useState<User | null>(null)
@@ -73,6 +74,8 @@ export default function ProfilePage() {
         return <GitHubIcon className="h-5 w-5" />
       case 'discord':
         return <DiscordIcon className="h-5 w-5" />
+      case 'oidc':
+        return <OIDCIcon className="h-5 w-5" />
       default:
         return null
     }
@@ -88,6 +91,8 @@ export default function ProfilePage() {
         return 'Discord'
       case 'local':
         return 'Email & Password'
+      case 'oidc':
+        return 'SSO'
       default:
         return provider
     }

--- a/frontend/components/OAuthButton.tsx
+++ b/frontend/components/OAuthButton.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api'
 import GoogleIcon from './icons/GoogleIcon'
 import GitHubIcon from './icons/GitHubIcon'
 import DiscordIcon from './icons/DiscordIcon'
+import OIDCIcon from './icons/OIDCIcon'
 
 interface OAuthButtonProps {
   provider: OAuthProvider
@@ -38,6 +39,14 @@ const providerConfig = {
     bgColor: 'bg-[#5865F2] hover:bg-[#4752C4]',
     textColor: 'text-white',
     borderColor: 'border-[#5865F2]',
+  },
+  oidc: {
+    name: 'SSO',
+    icon: OIDCIcon,
+    iconSize: 'h-5 w-5',
+    bgColor: 'bg-gray-700 hover:bg-gray-600',
+    textColor: 'text-white',
+    borderColor: 'border-gray-700',
   },
 }
 

--- a/frontend/components/icons/OIDCIcon.tsx
+++ b/frontend/components/icons/OIDCIcon.tsx
@@ -1,0 +1,21 @@
+interface OIDCIconProps {
+  className?: string
+}
+
+export default function OIDCIcon({ className = 'w-5 h-5' }: OIDCIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  )
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -4,7 +4,7 @@ export interface User {
   email: string
   name: string
   role: 'admin' | 'user'
-  provider: 'local' | 'google' | 'github' | 'discord'
+  provider: 'local' | 'google' | 'github' | 'discord' | 'oidc'
   avatar_url?: string
   email_verified: boolean
   last_activity_at?: string
@@ -227,7 +227,7 @@ export interface MetricsResponse {
 export type TimeRangeOption = '1h' | '6h' | '24h' | '7d' | '30d'
 
 // OAuth types
-export type OAuthProvider = 'google' | 'github' | 'discord'
+export type OAuthProvider = 'google' | 'github' | 'discord' | 'oidc'
 
 export interface OAuthProviderConfig {
   name: OAuthProvider


### PR DESCRIPTION
## Summary

- Adds a fourth OAuth provider (`oidc`) backed by automatic OIDC discovery — no hardcoded endpoints, no new Go dependencies
- At startup, fetches `{OIDC_ISSUER_URL}/.well-known/openid-configuration` to discover auth/token/userinfo URLs; failure logs a warning and disables the provider gracefully
- Follows the existing Google/GitHub/Discord pattern exactly throughout backend and frontend so there's no new maintenance surface

## Configuration

```env
OIDC_ISSUER_URL=https://auth.example.com/realms/master
OIDC_CLIENT_ID=nimbus
OIDC_CLIENT_SECRET=your-secret
OIDC_REDIRECT_URL=https://nimbus.example.com/api/v1/auth/oauth/oidc/callback
```

Works with any compliant provider: Keycloak, Authentik, Dex, Okta, Auth0, etc.

## Changes

**Backend**
- `models/oauth.go` — `ProviderOIDC` constant, `IssuerURL` field on `OAuthConfig`, `IsValid()` updated
- `config/config.go` — `GetOIDCConfig()` reading `OIDC_*` env vars
- `services/oauth_service.go` — `discoverOIDCEndpoints()` at startup, `fetchOIDCUserInfo()` (same shape as Google's), wired into `fetchUserInfo` switch; `NewOAuthService` gains an `oidcConfig` param; handles `email_verified` as bool or string for Keycloak/Authentik compat; falls back to `given_name`+`family_name` when `name` claim is absent
- `handlers/oauth_handler.go` — OIDC added to `GetProviderStatus`
- `cmd/server/main.go` — wired up

**Frontend**
- `types/index.ts` — `'oidc'` added to `OAuthProvider` and `User.provider` unions
- `components/icons/OIDCIcon.tsx` — new lock icon (generic SSO)
- `components/OAuthButton.tsx` — `oidc` entry, grey styling, "SSO" label
- `app/(auth)/login/page.tsx` — SSO button rendered when provider is enabled
- `app/(dashboard)/settings/profile/page.tsx` — icon and display name for OIDC users

**Docs**
- `.env.example` — OIDC vars documented with example issuer URLs
- `docker-compose.yml` — commented-out OIDC env var block

<details>
<summary>Test results</summary>

**Method:** Go backend run locally against a throwaway Postgres container (`postgres:17-alpine`). Tested via `curl` against `http://localhost:8080`.

**Verdict: PASS**

| # | What | Result |
|---|------|--------|
| 1 | No OIDC env vars → `GET /providers` | `oidc` present, `enabled: false`. Other three providers unaffected. |
| 2 | `OIDC_ISSUER_URL=https://accounts.google.com` + fake client → startup | Clean — no errors. |
| 3 | `GET /providers` with valid config | `oidc: enabled: true`, others still `false`. |
| 4 | `GET /api/v1/auth/oauth/oidc` (initiate flow) | 307 → Google's discovered auth URL with scopes `openid profile email`, correct `redirect_uri`, JWT state token. |
| 5 | Callback with bad state | 307 → `/login?error=Invalid+OAuth+state` — same behaviour as other providers. |
| 🔍 | Unreachable issuer (`no such host`) | Logged `OIDC provider disabled: … no such host`; server started healthy; provider `enabled: false`. |
| 🔍 | `OIDC_ISSUER_URL` set, `OIDC_CLIENT_ID` empty | Discovery never attempted, provider silently disabled. No log noise. |
| 🔍 | Discovery doc missing `authorization_endpoint`/`token_endpoint` | Logged `discovery document missing required endpoints`; server healthy; provider disabled. |
| 🔍 | `GET /api/v1/auth/oauth/notareal` | `{"error":"Invalid OAuth provider"}` — existing validation covers it. |

**Findings:**
- Successful discovery is silent in the logs. A startup log line like `OIDC provider configured (auth=…)` would help operators confirm their issuer URL resolved correctly.
- `OIDC_ISSUER_URL` set without `OIDC_CLIENT_ID` is silently ignored — correct behaviour, but a hint log would help users who half-configure it.

</details>

🤖 Generated with Claude Sonnet 4.6

fixes https://github.com/Turbootzz/Nimbus/issues/165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generic OIDC/SSO sign-in support with issuer-based discovery and configurable OIDC credentials.
  * Login screen now conditionally shows an **SSO** option when OIDC is available.
  * Profile settings display **SSO** with an OIDC icon for OIDC-authenticated users.
* **Bug Fixes**
  * Improved OIDC discovery and user-info handling, including resilient name fallbacks and `email_verified` normalization.
* **Documentation**
  * Updated environment and deployment templates with commented OIDC variables (issuer, client credentials, redirect URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->