### PR TITLE
chore: add GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [Turbootzz]


### PR DESCRIPTION
Adds a `.github/FUNDING.yml` so a **Sponsor** button appears on the repository pointing to the `Turbootzz` GitHub Sponsors profile.

## Changes
- Add `.github/FUNDING.yml` with `github: [Turbootzz]`