### PR TITLE
feat(smtp): make TLS optional for outgoing mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,10 @@
 # SMTP_PASSWORD=
 # SMTP_FROM_EMAIL=noreply@yourdomain.com
 # SMTP_FROM_NAME=Nimbus
+# Encryption: starttls, tls or none. Empty = tls on port 465, starttls otherwise.
+# Use none only for a trusted local relay; it rejects credentials.
+# SMTP_TLS_MODE=
+# SMTP_TLS_SKIP_VERIFY=false
 
 # Prometheus Integration
 # Generate API key with: openssl rand -hex 32

--- a/backend/internal/handlers/settings_handler.go
+++ b/backend/internal/handlers/settings_handler.go
@@ -12,7 +12,14 @@ import (
 	"github.com/nimbus/backend/internal/services"
 )
 
-const invalidTLSModeError = "SMTP TLS mode must be 'starttls', 'tls' or 'none'"
+const (
+	invalidTLSModeError       = "SMTP TLS mode must be 'starttls', 'tls' or 'none'"
+	plaintextCredentialsError = "SMTP username and password must be empty when encryption is disabled"
+)
+
+func isNoTLS(mode string) bool {
+	return strings.EqualFold(strings.TrimSpace(mode), services.TLSModeNone)
+}
 
 type SettingsHandler struct {
 	settingsRepo *repository.SettingsRepository
@@ -24,6 +31,15 @@ func NewSettingsHandler(settingsRepo *repository.SettingsRepository, emailServic
 		settingsRepo: settingsRepo,
 		emailService: emailService,
 	}
+}
+
+// storedSetting returns the saved value, or "" when it is missing
+func (h *SettingsHandler) storedSetting(c *fiber.Ctx, key string) string {
+	setting, err := h.settingsRepo.Get(c.Context(), key)
+	if err != nil {
+		return ""
+	}
+	return setting.Value
 }
 
 // GetSettings returns all system settings (admin only)
@@ -121,6 +137,17 @@ func (h *SettingsHandler) UpdateSetting(c *fiber.Ctx) error {
 				"error": invalidTLSModeError,
 			})
 		}
+		if isNoTLS(req.Value) && (h.storedSetting(c, "smtp_username") != "" || h.storedSetting(c, "smtp_password") != "") {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": plaintextCredentialsError,
+			})
+		}
+	case "smtp_username", "smtp_password":
+		if req.Value != "" && isNoTLS(h.storedSetting(c, "smtp_tls_mode")) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": plaintextCredentialsError,
+			})
+		}
 	}
 
 	// Get current user ID for audit trail
@@ -175,8 +202,12 @@ func (r smtpSettingsRequest) tlsSkipVerify() string {
 	return *r.TLSSkipVerify
 }
 
-func (r smtpSettingsRequest) usesNoTLS() bool {
-	return strings.EqualFold(strings.TrimSpace(r.tlsMode()), services.TLSModeNone)
+// effectiveTLSMode is the request's mode, or the stored one when it is omitted
+func (h *SettingsHandler) effectiveTLSMode(c *fiber.Ctx, req smtpSettingsRequest) string {
+	if req.TLSMode != nil {
+		return *req.TLSMode
+	}
+	return h.storedSetting(c, "smtp_tls_mode")
 }
 
 // UpdateSMTPSettings saves all SMTP settings atomically
@@ -208,9 +239,9 @@ func (h *SettingsHandler) UpdateSMTPSettings(c *fiber.Ctx) error {
 	}
 
 	// Reject at save time what the send path would reject anyway
-	if req.usesNoTLS() && (req.Username != "" || req.Password != "") {
+	if isNoTLS(h.effectiveTLSMode(c, req)) && (req.Username != "" || req.Password != "") {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "SMTP username and password must be empty when encryption is disabled",
+			"error": plaintextCredentialsError,
 		})
 	}
 
@@ -311,7 +342,7 @@ func (h *SettingsHandler) TestSMTPConnection(c *fiber.Ctx) error {
 			TLSMode:       req.tlsMode(),
 			TLSSkipVerify: req.tlsSkipVerify() == "true",
 		}
-		testErr = h.emailService.TestConnectionWithConfig(config)
+		testErr = h.emailService.TestConnectionWithConfig(c.Context(), config)
 	} else {
 		// Fall back to saved config
 		testErr = h.emailService.TestConnection(c.Context())

--- a/backend/internal/handlers/settings_handler.go
+++ b/backend/internal/handlers/settings_handler.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/nimbus/backend/internal/models"
 	"github.com/nimbus/backend/internal/repository"
 	"github.com/nimbus/backend/internal/services"
 )
+
+const invalidTLSModeError = "SMTP TLS mode must be 'starttls', 'tls' or 'none'"
 
 type SettingsHandler struct {
 	settingsRepo *repository.SettingsRepository
@@ -94,7 +97,7 @@ func (h *SettingsHandler) UpdateSetting(c *fiber.Ctx) error {
 
 	// Validate value for known settings
 	switch key {
-	case "public_registration_enabled", "smtp_enabled":
+	case "public_registration_enabled", "smtp_enabled", "smtp_tls_skip_verify":
 		if req.Value != "true" && req.Value != "false" {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"error": "Value must be 'true' or 'false'",
@@ -110,6 +113,12 @@ func (h *SettingsHandler) UpdateSetting(c *fiber.Ctx) error {
 		if err != nil || port < 1 || port > 65535 {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"error": "SMTP port must be a valid number",
+			})
+		}
+	case "smtp_tls_mode":
+		if !services.IsValidTLSMode(req.Value) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": invalidTLSModeError,
 			})
 		}
 	}
@@ -139,17 +148,40 @@ func (h *SettingsHandler) UpdateSetting(c *fiber.Ctx) error {
 	return c.JSON(setting)
 }
 
+// TLS fields are pointers so an omitted field leaves the stored value untouched
+type smtpSettingsRequest struct {
+	Host          string  `json:"smtp_host"`
+	Port          string  `json:"smtp_port"`
+	Username      string  `json:"smtp_username"`
+	Password      string  `json:"smtp_password"`
+	FromEmail     string  `json:"smtp_from_email"`
+	FromName      string  `json:"smtp_from_name"`
+	Enabled       string  `json:"smtp_enabled"`
+	TLSMode       *string `json:"smtp_tls_mode"`
+	TLSSkipVerify *string `json:"smtp_tls_skip_verify"`
+}
+
+func (r smtpSettingsRequest) tlsMode() string {
+	if r.TLSMode == nil {
+		return ""
+	}
+	return *r.TLSMode
+}
+
+func (r smtpSettingsRequest) tlsSkipVerify() string {
+	if r.TLSSkipVerify == nil {
+		return ""
+	}
+	return *r.TLSSkipVerify
+}
+
+func (r smtpSettingsRequest) usesNoTLS() bool {
+	return strings.EqualFold(strings.TrimSpace(r.tlsMode()), services.TLSModeNone)
+}
+
 // UpdateSMTPSettings saves all SMTP settings atomically
 func (h *SettingsHandler) UpdateSMTPSettings(c *fiber.Ctx) error {
-	var req struct {
-		Host      string `json:"smtp_host"`
-		Port      string `json:"smtp_port"`
-		Username  string `json:"smtp_username"`
-		Password  string `json:"smtp_password"`
-		FromEmail string `json:"smtp_from_email"`
-		FromName  string `json:"smtp_from_name"`
-		Enabled   string `json:"smtp_enabled"`
-	}
+	var req smtpSettingsRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body",
@@ -160,6 +192,25 @@ func (h *SettingsHandler) UpdateSMTPSettings(c *fiber.Ctx) error {
 	if req.Enabled != "true" && req.Enabled != "false" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "smtp_enabled must be 'true' or 'false'",
+		})
+	}
+
+	if v := req.tlsSkipVerify(); v != "" && v != "true" && v != "false" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "smtp_tls_skip_verify must be 'true' or 'false'",
+		})
+	}
+
+	if !services.IsValidTLSMode(req.tlsMode()) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": invalidTLSModeError,
+		})
+	}
+
+	// Reject at save time what the send path would reject anyway
+	if req.usesNoTLS() && (req.Username != "" || req.Password != "") {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "SMTP username and password must be empty when encryption is disabled",
 		})
 	}
 
@@ -201,6 +252,12 @@ func (h *SettingsHandler) UpdateSMTPSettings(c *fiber.Ctx) error {
 		"smtp_from_name":  req.FromName,
 		"smtp_enabled":    req.Enabled,
 	}
+	if req.TLSMode != nil {
+		settings["smtp_tls_mode"] = *req.TLSMode
+	}
+	if req.TLSSkipVerify != nil {
+		settings["smtp_tls_skip_verify"] = *req.TLSSkipVerify
+	}
 
 	if err := h.settingsRepo.UpdateBatch(c.Context(), settings, &userID); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -226,17 +283,16 @@ func (h *SettingsHandler) TestSMTPConnection(c *fiber.Ctx) error {
 	var testErr error
 
 	// Try to parse inline config from request body
-	var req struct {
-		Host      string `json:"smtp_host"`
-		Port      string `json:"smtp_port"`
-		Username  string `json:"smtp_username"`
-		Password  string `json:"smtp_password"`
-		FromEmail string `json:"smtp_from_email"`
-		FromName  string `json:"smtp_from_name"`
-		Enabled   string `json:"smtp_enabled"`
-	}
+	var req smtpSettingsRequest
 
 	if len(c.Body()) > 0 && c.BodyParser(&req) == nil && req.Host != "" {
+		if !services.IsValidTLSMode(req.tlsMode()) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"success": false,
+				"message": invalidTLSModeError,
+			})
+		}
+
 		// Use inline config for pre-save testing
 		port := 587
 		if req.Port != "" {
@@ -245,13 +301,15 @@ func (h *SettingsHandler) TestSMTPConnection(c *fiber.Ctx) error {
 			}
 		}
 		config := &services.SMTPConfig{
-			Host:      req.Host,
-			Port:      port,
-			Username:  req.Username,
-			Password:  req.Password,
-			FromEmail: req.FromEmail,
-			FromName:  req.FromName,
-			Enabled:   req.Enabled != "false",
+			Host:          req.Host,
+			Port:          port,
+			Username:      req.Username,
+			Password:      req.Password,
+			FromEmail:     req.FromEmail,
+			FromName:      req.FromName,
+			Enabled:       req.Enabled != "false",
+			TLSMode:       req.tlsMode(),
+			TLSSkipVerify: req.tlsSkipVerify() == "true",
 		}
 		testErr = h.emailService.TestConnectionWithConfig(config)
 	} else {

--- a/backend/internal/handlers/settings_handler_test.go
+++ b/backend/internal/handlers/settings_handler_test.go
@@ -1102,3 +1102,89 @@ func TestSettingsHandler_UpdateSetting_InvalidTLSMode(t *testing.T) {
 		t.Errorf("Expected status 400 for invalid TLS mode, got %d", resp.StatusCode)
 	}
 }
+
+func putSetting(t *testing.T, db *sql.DB, key, value string) *http.Response {
+	t.Helper()
+
+	settingsRepo := repository.NewSettingsRepository(db)
+	handler := NewSettingsHandler(settingsRepo, services.NewEmailService(settingsRepo))
+
+	app := fiber.New()
+	app.Put("/admin/settings/:key", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "admin-1")
+		return handler.UpdateSetting(c)
+	})
+
+	body, _ := json.Marshal(map[string]string{"value": value})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings/"+key, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	return resp
+}
+
+func seedSetting(t *testing.T, db *sql.DB, key, value string) {
+	t.Helper()
+
+	if _, err := db.Exec("INSERT INTO system_settings (key, value) VALUES (?, ?)", key, value); err != nil {
+		t.Fatalf("Failed to seed %s: %v", key, err)
+	}
+}
+
+func TestSettingsHandler_UpdateSetting_NoTLSWithStoredCredentialsRejected(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	seedSetting(t, db, "smtp_username", "user")
+
+	if resp := putSetting(t, db, "smtp_tls_mode", "none"); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 when disabling TLS with stored credentials, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettingsHandler_UpdateSetting_CredentialsWithStoredNoTLSRejected(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	seedSetting(t, db, "smtp_tls_mode", "none")
+
+	if resp := putSetting(t, db, "smtp_password", "secret"); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 when adding credentials to an unencrypted relay, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettingsHandler_UpdateSetting_ClearingCredentialsAllowed(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	seedSetting(t, db, "smtp_tls_mode", "none")
+	seedSetting(t, db, "smtp_username", "user")
+
+	if resp := putSetting(t, db, "smtp_username", ""); resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200 when clearing credentials, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettingsHandler_UpdateSMTPSettings_CredentialsWithStoredNoTLSRejected(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	seedSetting(t, db, "smtp_tls_mode", "none")
+
+	// Omitting smtp_tls_mode must not sidestep the stored 'none' mode
+	resp := putSMTPSettings(t, newSMTPSettingsApp(t, db), map[string]string{
+		"smtp_host":       "mailpit",
+		"smtp_port":       "1025",
+		"smtp_username":   "user",
+		"smtp_password":   "secret",
+		"smtp_from_email": "noreply@example.com",
+		"smtp_enabled":    "true",
+	})
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for credentials against a stored 'none' mode, got %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/handlers/settings_handler_test.go
+++ b/backend/internal/handlers/settings_handler_test.go
@@ -933,3 +933,172 @@ func TestSettingsHandler_GetSMTPStatus_Env(t *testing.T) {
 		t.Errorf("Expected source 'env', got '%v'", result["source"])
 	}
 }
+
+func newSMTPSettingsApp(t *testing.T, db *sql.DB) *fiber.App {
+	t.Helper()
+
+	settingsRepo := repository.NewSettingsRepository(db)
+	handler := NewSettingsHandler(settingsRepo, services.NewEmailService(settingsRepo))
+
+	app := fiber.New()
+	app.Put("/admin/settings/smtp", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "admin-1")
+		return handler.UpdateSMTPSettings(c)
+	})
+	return app
+}
+
+func putSMTPSettings(t *testing.T, app *fiber.App, payload map[string]string) *http.Response {
+	t.Helper()
+
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings/smtp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	return resp
+}
+
+func TestSettingsHandler_UpdateSMTPSettings_SavesTLSMode(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	resp := putSMTPSettings(t, newSMTPSettingsApp(t, db), map[string]string{
+		"smtp_host":            "mailpit",
+		"smtp_port":            "1025",
+		"smtp_from_email":      "noreply@example.com",
+		"smtp_enabled":         "true",
+		"smtp_tls_mode":        "none",
+		"smtp_tls_skip_verify": "false",
+	})
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	var value string
+	if err := db.QueryRow("SELECT value FROM system_settings WHERE key = ?", "smtp_tls_mode").Scan(&value); err != nil {
+		t.Fatalf("Failed to query smtp_tls_mode: %v", err)
+	}
+	if value != "none" {
+		t.Errorf("Expected smtp_tls_mode 'none', got '%s'", value)
+	}
+}
+
+func TestSettingsHandler_UpdateSMTPSettings_InvalidTLSMode(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	resp := putSMTPSettings(t, newSMTPSettingsApp(t, db), map[string]string{
+		"smtp_host":       "smtp.example.com",
+		"smtp_from_email": "noreply@example.com",
+		"smtp_enabled":    "true",
+		"smtp_tls_mode":   "ssl",
+	})
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for invalid TLS mode, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettingsHandler_UpdateSMTPSettings_InvalidSkipVerify(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	resp := putSMTPSettings(t, newSMTPSettingsApp(t, db), map[string]string{
+		"smtp_host":            "smtp.example.com",
+		"smtp_from_email":      "noreply@example.com",
+		"smtp_enabled":         "true",
+		"smtp_tls_skip_verify": "yes",
+	})
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for invalid skip verify value, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettingsHandler_UpdateSMTPSettings_CredentialsWithoutTLSRejected(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	resp := putSMTPSettings(t, newSMTPSettingsApp(t, db), map[string]string{
+		"smtp_host":       "mailpit",
+		"smtp_port":       "1025",
+		"smtp_username":   "user",
+		"smtp_password":   "secret",
+		"smtp_from_email": "noreply@example.com",
+		"smtp_enabled":    "true",
+		"smtp_tls_mode":   "none",
+	})
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for credentials without TLS, got %d", resp.StatusCode)
+	}
+}
+
+// An older client that does not know the TLS fields must not wipe them
+func TestSettingsHandler_UpdateSMTPSettings_OmittedTLSFieldsKeepStoredValue(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	app := newSMTPSettingsApp(t, db)
+
+	resp := putSMTPSettings(t, app, map[string]string{
+		"smtp_host":       "mailpit",
+		"smtp_port":       "1025",
+		"smtp_from_email": "noreply@example.com",
+		"smtp_enabled":    "true",
+		"smtp_tls_mode":   "none",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	resp = putSMTPSettings(t, app, map[string]string{
+		"smtp_host":       "mailpit",
+		"smtp_port":       "1025",
+		"smtp_from_email": "noreply@example.com",
+		"smtp_enabled":    "true",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status 200 when TLS mode is omitted, got %d", resp.StatusCode)
+	}
+
+	var value string
+	if err := db.QueryRow("SELECT value FROM system_settings WHERE key = ?", "smtp_tls_mode").Scan(&value); err != nil {
+		t.Fatalf("Failed to query smtp_tls_mode: %v", err)
+	}
+	if value != "none" {
+		t.Errorf("Expected stored smtp_tls_mode to remain 'none', got '%s'", value)
+	}
+}
+
+func TestSettingsHandler_UpdateSetting_InvalidTLSMode(t *testing.T) {
+	db := setupSettingsTestDB(t)
+	defer db.Close()
+
+	settingsRepo := repository.NewSettingsRepository(db)
+	handler := NewSettingsHandler(settingsRepo, services.NewEmailService(settingsRepo))
+
+	app := fiber.New()
+	app.Put("/admin/settings/:key", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "admin-1")
+		return handler.UpdateSetting(c)
+	})
+
+	body, _ := json.Marshal(map[string]string{"value": "ssl"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/settings/smtp_tls_mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for invalid TLS mode, got %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/services/email_service.go
+++ b/backend/internal/services/email_service.go
@@ -18,18 +18,55 @@ import (
 	"github.com/nimbus/backend/internal/repository"
 )
 
-const smtpDialTimeout = 10 * time.Second
+const (
+	smtpDialTimeout    = 10 * time.Second
+	smtpSessionTimeout = 30 * time.Second
+)
+
+// TLS modes for outgoing SMTP connections
+const (
+	TLSModeSTARTTLS = "starttls" // plaintext connection upgraded via STARTTLS
+	TLSModeImplicit = "tls"      // TLS from the first byte, typically port 465
+	TLSModeNone     = "none"     // no encryption, for trusted local relays only
+)
 
 // SMTPConfig holds SMTP connection settings
 type SMTPConfig struct {
-	Host       string
-	Port       int
-	Username   string
-	Password   string
-	FromEmail  string
-	FromName   string
-	Enabled    bool
-	enabledSet bool // tracks whether Enabled was explicitly configured
+	Host          string
+	Port          int
+	Username      string
+	Password      string
+	FromEmail     string
+	FromName      string
+	Enabled       bool
+	TLSMode       string // one of the TLSMode constants; empty derives from the port
+	TLSSkipVerify bool   // skip certificate verification (self-signed relays)
+	enabledSet    bool   // tracks whether Enabled was explicitly configured
+}
+
+// IsValidTLSMode reports whether mode is supported; empty means "derive from port"
+func IsValidTLSMode(mode string) bool {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", TLSModeSTARTTLS, TLSModeImplicit, TLSModeNone:
+		return true
+	}
+	return false
+}
+
+// resolveTLSMode normalizes mode; unset falls back to implicit TLS on 465, STARTTLS elsewhere
+func resolveTLSMode(mode string, port int) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case TLSModeSTARTTLS:
+		return TLSModeSTARTTLS
+	case TLSModeImplicit:
+		return TLSModeImplicit
+	case TLSModeNone:
+		return TLSModeNone
+	}
+	if port == 465 {
+		return TLSModeImplicit
+	}
+	return TLSModeSTARTTLS
 }
 
 type EmailService struct {
@@ -43,6 +80,7 @@ func NewEmailService(settingsRepo *repository.SettingsRepository) *EmailService 
 // GetSMTPConfig loads SMTP config from system_settings with env var fallback
 func (s *EmailService) GetSMTPConfig(ctx context.Context) (*SMTPConfig, error) {
 	config := &SMTPConfig{}
+	skipVerifySet := false
 
 	// Try loading from system_settings first
 	settings, err := s.settingsRepo.GetAll(ctx)
@@ -76,6 +114,13 @@ func (s *EmailService) GetSMTPConfig(ctx context.Context) (*SMTPConfig, error) {
 			config.Enabled = v == "true"
 			config.enabledSet = true
 		}
+		if v, ok := settingsMap["smtp_tls_mode"]; ok && v != "" {
+			config.TLSMode = v
+		}
+		if v, ok := settingsMap["smtp_tls_skip_verify"]; ok && v != "" {
+			config.TLSSkipVerify = v == "true"
+			skipVerifySet = true
+		}
 	}
 
 	// Fall back to env vars for any unset values
@@ -89,12 +134,6 @@ func (s *EmailService) GetSMTPConfig(ctx context.Context) (*SMTPConfig, error) {
 			}
 		}
 	}
-	if config.Username == "" {
-		config.Username = os.Getenv("SMTP_USERNAME")
-	}
-	if config.Password == "" {
-		config.Password = os.Getenv("SMTP_PASSWORD")
-	}
 	if config.FromEmail == "" {
 		config.FromEmail = os.Getenv("SMTP_FROM_EMAIL")
 	}
@@ -102,6 +141,23 @@ func (s *EmailService) GetSMTPConfig(ctx context.Context) (*SMTPConfig, error) {
 		config.FromName = os.Getenv("SMTP_FROM_NAME")
 		if config.FromName == "" {
 			config.FromName = "Nimbus"
+		}
+	}
+	if config.TLSMode == "" {
+		config.TLSMode = os.Getenv("SMTP_TLS_MODE")
+	}
+	if !skipVerifySet {
+		config.TLSSkipVerify = os.Getenv("SMTP_TLS_SKIP_VERIFY") == "true"
+	}
+
+	// Credentials are unusable without encryption, so don't resurrect env
+	// leftovers that the admin cleared for an unencrypted relay
+	if resolveTLSMode(config.TLSMode, config.Port) != TLSModeNone {
+		if config.Username == "" {
+			config.Username = os.Getenv("SMTP_USERNAME")
+		}
+		if config.Password == "" {
+			config.Password = os.Getenv("SMTP_PASSWORD")
 		}
 	}
 
@@ -146,12 +202,8 @@ func (s *EmailService) SendEmail(ctx context.Context, to, subject, htmlBody stri
 		return fmt.Errorf("failed to get SMTP config: %w", err)
 	}
 
-	if !config.Enabled || config.Host == "" {
-		return errors.New("SMTP is not configured")
-	}
-
-	if config.Port == 0 {
-		config.Port = 587
+	if err := prepareSMTPConfig(config); err != nil {
+		return err
 	}
 
 	from := config.FromEmail
@@ -170,14 +222,35 @@ func (s *EmailService) SendEmail(ctx context.Context, to, subject, htmlBody stri
 		encodedName, from, to, subject)
 	msg := []byte(headers + htmlBody)
 
-	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
+	c, err := dialSMTP(config)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
 
-	// Use TLS for port 465, STARTTLS for others
-	if config.Port == 465 {
-		return s.sendWithImplicitTLS(config, addr, from, to, msg)
+	if err := authenticateSMTP(c, config); err != nil {
+		return err
 	}
 
-	return s.sendWithSTARTTLS(config, addr, from, to, msg)
+	if err := c.Mail(from); err != nil {
+		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
+	}
+	if err := c.Rcpt(to); err != nil {
+		return fmt.Errorf("SMTP RCPT TO failed: %w", err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("SMTP DATA failed: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("failed to write email body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("failed to close email writer: %w", err)
+	}
+
+	return c.Quit()
 }
 
 // sanitizeHeader strips CR and LF characters to prevent CRLF header injection
@@ -185,104 +258,98 @@ func sanitizeHeader(s string) string {
 	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
 }
 
-// sendWithSTARTTLS sends email using STARTTLS (port 587)
-func (s *EmailService) sendWithSTARTTLS(config *SMTPConfig, addr, from, to string, msg []byte) error {
-	dialer := net.Dialer{Timeout: smtpDialTimeout}
-	conn, err := dialer.Dial("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("failed to connect to SMTP server: %w", err)
+// prepareSMTPConfig validates a config and applies the port and TLS mode defaults.
+func prepareSMTPConfig(config *SMTPConfig) error {
+	if !config.Enabled || config.Host == "" {
+		return errors.New("SMTP is not configured")
 	}
 
-	c, err := smtp.NewClient(conn, config.Host)
-	if err != nil {
-		conn.Close()
-		return fmt.Errorf("failed to create SMTP client: %w", err)
+	if config.Port == 0 {
+		config.Port = 587
 	}
-	defer c.Close()
+	config.TLSMode = resolveTLSMode(config.TLSMode, config.Port)
 
-	// Check if server supports STARTTLS before attempting
-	if ok, _ := c.Extension("STARTTLS"); !ok {
-		return errors.New("SMTP server does not support STARTTLS")
+	// Credentials would travel in cleartext without encryption
+	if config.TLSMode == TLSModeNone && config.Username != "" && config.Password != "" {
+		return errors.New("SMTP authentication requires TLS: use the starttls or tls mode, or clear the username and password")
 	}
 
-	tlsConfig := &tls.Config{ServerName: config.Host, MinVersion: tls.VersionTLS12}
-	if err := c.StartTLS(tlsConfig); err != nil {
-		return fmt.Errorf("STARTTLS failed: %w", err)
-	}
-
-	// Auth if credentials provided
-	if config.Username != "" && config.Password != "" {
-		auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
-		if err := c.Auth(auth); err != nil {
-			return fmt.Errorf("SMTP authentication failed: %w", err)
-		}
-	}
-
-	if err := c.Mail(from); err != nil {
-		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
-	}
-	if err := c.Rcpt(to); err != nil {
-		return fmt.Errorf("SMTP RCPT TO failed: %w", err)
-	}
-
-	w, err := c.Data()
-	if err != nil {
-		return fmt.Errorf("SMTP DATA failed: %w", err)
-	}
-	if _, err := w.Write(msg); err != nil {
-		return fmt.Errorf("failed to write email body: %w", err)
-	}
-	if err := w.Close(); err != nil {
-		return fmt.Errorf("failed to close email writer: %w", err)
-	}
-
-	return c.Quit()
+	return nil
 }
 
-// sendWithImplicitTLS sends email using implicit TLS (port 465)
-func (s *EmailService) sendWithImplicitTLS(config *SMTPConfig, addr, from, to string, msg []byte) error {
-	tlsConfig := &tls.Config{ServerName: config.Host, MinVersion: tls.VersionTLS12}
+func tlsConfigFor(config *SMTPConfig) *tls.Config {
+	return &tls.Config{
+		ServerName:         config.Host,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: config.TLSSkipVerify, //nolint:gosec // opt-in for self-signed relays
+	}
+}
+
+// dialSMTP opens an SMTP client using the config's TLS mode. Caller must close it.
+func dialSMTP(config *SMTPConfig) (*smtp.Client, error) {
+	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 	dialer := net.Dialer{Timeout: smtpDialTimeout}
 
-	conn, err := tls.DialWithDialer(&dialer, "tcp", addr, tlsConfig)
-	if err != nil {
-		return fmt.Errorf("failed to connect via TLS: %w", err)
+	if config.TLSMode == TLSModeImplicit {
+		conn, err := tls.DialWithDialer(&dialer, "tcp", addr, tlsConfigFor(config))
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect via TLS: %w", err)
+		}
+		return newSMTPClient(conn, config.Host)
 	}
 
-	c, err := smtp.NewClient(conn, config.Host)
+	conn, err := dialer.Dial("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to SMTP server: %w", err)
+	}
+
+	c, err := newSMTPClient(conn, config.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.TLSMode == TLSModeNone {
+		return c, nil
+	}
+
+	if ok, _ := c.Extension("STARTTLS"); !ok {
+		c.Close()
+		return nil, errors.New("SMTP server does not support STARTTLS")
+	}
+	if err := c.StartTLS(tlsConfigFor(config)); err != nil {
+		c.Close()
+		return nil, fmt.Errorf("STARTTLS failed: %w", err)
+	}
+
+	return c, nil
+}
+
+func newSMTPClient(conn net.Conn, host string) (*smtp.Client, error) {
+	// A TLS-only port accepts the connection but never sends a plaintext
+	// greeting, so bound the session instead of blocking forever
+	if err := conn.SetDeadline(time.Now().Add(smtpSessionTimeout)); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to set SMTP connection deadline: %w", err)
+	}
+
+	c, err := smtp.NewClient(conn, host)
 	if err != nil {
 		conn.Close()
-		return fmt.Errorf("failed to create SMTP client: %w", err)
+		return nil, fmt.Errorf("failed to create SMTP client: %w", err)
 	}
-	defer c.Close()
+	return c, nil
+}
 
-	// Auth if credentials provided
-	if config.Username != "" && config.Password != "" {
-		auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
-		if err := c.Auth(auth); err != nil {
-			return fmt.Errorf("SMTP authentication failed: %w", err)
-		}
+func authenticateSMTP(c *smtp.Client, config *SMTPConfig) error {
+	if config.Username == "" || config.Password == "" {
+		return nil
 	}
 
-	if err := c.Mail(from); err != nil {
-		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
+	auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
+	if err := c.Auth(auth); err != nil {
+		return fmt.Errorf("SMTP authentication failed: %w", err)
 	}
-	if err := c.Rcpt(to); err != nil {
-		return fmt.Errorf("SMTP RCPT TO failed: %w", err)
-	}
-
-	w, err := c.Data()
-	if err != nil {
-		return fmt.Errorf("SMTP DATA failed: %w", err)
-	}
-	if _, err := w.Write(msg); err != nil {
-		return fmt.Errorf("failed to write email body: %w", err)
-	}
-	if err := w.Close(); err != nil {
-		return fmt.Errorf("failed to close email writer: %w", err)
-	}
-
-	return c.Quit()
+	return nil
 }
 
 // SendPasswordResetEmail sends a password reset email
@@ -318,68 +385,18 @@ func (s *EmailService) TestConnection(ctx context.Context) error {
 
 // TestConnectionWithConfig tests the SMTP connection using the provided config
 func (s *EmailService) TestConnectionWithConfig(config *SMTPConfig) error {
-	if !config.Enabled || config.Host == "" {
-		return errors.New("SMTP is not configured")
+	if err := prepareSMTPConfig(config); err != nil {
+		return err
 	}
 
-	if config.Port == 0 {
-		config.Port = 587
-	}
-
-	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
-
-	dialer := net.Dialer{Timeout: smtpDialTimeout}
-
-	// Test TLS connection for port 465
-	if config.Port == 465 {
-		tlsConfig := &tls.Config{ServerName: config.Host, MinVersion: tls.VersionTLS12}
-		conn, err := tls.DialWithDialer(&dialer, "tcp", addr, tlsConfig)
-		if err != nil {
-			return fmt.Errorf("failed to connect via TLS: %w", err)
-		}
-		c, err := smtp.NewClient(conn, config.Host)
-		if err != nil {
-			conn.Close()
-			return fmt.Errorf("failed to create SMTP client: %w", err)
-		}
-		defer c.Close()
-
-		if config.Username != "" && config.Password != "" {
-			auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
-			if err := c.Auth(auth); err != nil {
-				return fmt.Errorf("SMTP authentication failed: %w", err)
-			}
-		}
-		return c.Quit()
-	}
-
-	// Test STARTTLS connection
-	conn, err := dialer.Dial("tcp", addr)
+	c, err := dialSMTP(config)
 	if err != nil {
-		return fmt.Errorf("failed to connect to SMTP server: %w", err)
-	}
-
-	c, err := smtp.NewClient(conn, config.Host)
-	if err != nil {
-		conn.Close()
-		return fmt.Errorf("failed to create SMTP client: %w", err)
+		return err
 	}
 	defer c.Close()
 
-	if ok, _ := c.Extension("STARTTLS"); !ok {
-		return errors.New("SMTP server does not support STARTTLS")
-	}
-
-	tlsConfig := &tls.Config{ServerName: config.Host, MinVersion: tls.VersionTLS12}
-	if err := c.StartTLS(tlsConfig); err != nil {
-		return fmt.Errorf("STARTTLS failed: %w", err)
-	}
-
-	if config.Username != "" && config.Password != "" {
-		auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
-		if err := c.Auth(auth); err != nil {
-			return fmt.Errorf("SMTP authentication failed: %w", err)
-		}
+	if err := authenticateSMTP(c, config); err != nil {
+		return err
 	}
 
 	return c.Quit()

--- a/backend/internal/services/email_service.go
+++ b/backend/internal/services/email_service.go
@@ -222,7 +222,7 @@ func (s *EmailService) SendEmail(ctx context.Context, to, subject, htmlBody stri
 		encodedName, from, to, subject)
 	msg := []byte(headers + htmlBody)
 
-	c, err := dialSMTP(config)
+	c, err := dialSMTP(ctx, config)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func prepareSMTPConfig(config *SMTPConfig) error {
 	config.TLSMode = resolveTLSMode(config.TLSMode, config.Port)
 
 	// Credentials would travel in cleartext without encryption
-	if config.TLSMode == TLSModeNone && config.Username != "" && config.Password != "" {
+	if config.TLSMode == TLSModeNone && (config.Username != "" || config.Password != "") {
 		return errors.New("SMTP authentication requires TLS: use the starttls or tls mode, or clear the username and password")
 	}
 
@@ -286,24 +286,25 @@ func tlsConfigFor(config *SMTPConfig) *tls.Config {
 }
 
 // dialSMTP opens an SMTP client using the config's TLS mode. Caller must close it.
-func dialSMTP(config *SMTPConfig) (*smtp.Client, error) {
+func dialSMTP(ctx context.Context, config *SMTPConfig) (*smtp.Client, error) {
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
-	dialer := net.Dialer{Timeout: smtpDialTimeout}
+	dialer := &net.Dialer{Timeout: smtpDialTimeout}
 
 	if config.TLSMode == TLSModeImplicit {
-		conn, err := tls.DialWithDialer(&dialer, "tcp", addr, tlsConfigFor(config))
+		tlsDialer := tls.Dialer{NetDialer: dialer, Config: tlsConfigFor(config)}
+		conn, err := tlsDialer.DialContext(ctx, "tcp", addr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect via TLS: %w", err)
 		}
-		return newSMTPClient(conn, config.Host)
+		return newSMTPClient(ctx, conn, config.Host)
 	}
 
-	conn, err := dialer.Dial("tcp", addr)
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to SMTP server: %w", err)
 	}
 
-	c, err := newSMTPClient(conn, config.Host)
+	c, err := newSMTPClient(ctx, conn, config.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -324,10 +325,14 @@ func dialSMTP(config *SMTPConfig) (*smtp.Client, error) {
 	return c, nil
 }
 
-func newSMTPClient(conn net.Conn, host string) (*smtp.Client, error) {
+func newSMTPClient(ctx context.Context, conn net.Conn, host string) (*smtp.Client, error) {
 	// A TLS-only port accepts the connection but never sends a plaintext
 	// greeting, so bound the session instead of blocking forever
-	if err := conn.SetDeadline(time.Now().Add(smtpSessionTimeout)); err != nil {
+	deadline := time.Now().Add(smtpSessionTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("failed to set SMTP connection deadline: %w", err)
 	}
@@ -380,16 +385,16 @@ func (s *EmailService) TestConnection(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get SMTP config: %w", err)
 	}
-	return s.TestConnectionWithConfig(config)
+	return s.TestConnectionWithConfig(ctx, config)
 }
 
 // TestConnectionWithConfig tests the SMTP connection using the provided config
-func (s *EmailService) TestConnectionWithConfig(config *SMTPConfig) error {
+func (s *EmailService) TestConnectionWithConfig(ctx context.Context, config *SMTPConfig) error {
 	if err := prepareSMTPConfig(config); err != nil {
 		return err
 	}
 
-	c, err := dialSMTP(config)
+	c, err := dialSMTP(ctx, config)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/services/email_service_test.go
+++ b/backend/internal/services/email_service_test.go
@@ -1,10 +1,15 @@
 package services
 
 import (
+	"bufio"
 	"context"
 	"database/sql"
+	"net"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nimbus/backend/internal/repository"
 
@@ -286,5 +291,317 @@ func TestTestConnectionWithConfig_DisabledSMTP(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("Expected error for disabled SMTP")
+	}
+}
+
+func TestIsValidTLSMode(t *testing.T) {
+	valid := []string{"", TLSModeSTARTTLS, TLSModeImplicit, TLSModeNone}
+	for _, mode := range valid {
+		if !IsValidTLSMode(mode) {
+			t.Errorf("Expected '%s' to be valid", mode)
+		}
+	}
+
+	// Values are normalized, so case and surrounding spaces are accepted
+	if !IsValidTLSMode("  STARTTLS ") {
+		t.Error("Expected normalized input to be valid")
+	}
+
+	invalid := []string{"ssl", "off", "true"}
+	for _, mode := range invalid {
+		if IsValidTLSMode(mode) {
+			t.Errorf("Expected '%s' to be invalid", mode)
+		}
+	}
+}
+
+func TestResolveTLSMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		port int
+		want string
+	}{
+		{"unset on 465 defaults to implicit TLS", "", 465, TLSModeImplicit},
+		{"unset on 587 defaults to STARTTLS", "", 587, TLSModeSTARTTLS},
+		{"unset on 1025 defaults to STARTTLS", "", 1025, TLSModeSTARTTLS},
+		{"explicit none wins over port", TLSModeNone, 465, TLSModeNone},
+		{"explicit STARTTLS wins over port", TLSModeSTARTTLS, 465, TLSModeSTARTTLS},
+		{"explicit implicit TLS on custom port", TLSModeImplicit, 2465, TLSModeImplicit},
+		{"case and spaces are normalized", "  NONE ", 587, TLSModeNone},
+		{"unknown value falls back to port default", "garbage", 465, TLSModeImplicit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveTLSMode(tt.mode, tt.port); got != tt.want {
+				t.Errorf("resolveTLSMode(%q, %d) = %q, want %q", tt.mode, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrepare_AppliesDefaults(t *testing.T) {
+	config := &SMTPConfig{Host: "smtp.example.com", Enabled: true}
+
+	if err := prepareSMTPConfig(config); err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if config.Port != 587 {
+		t.Errorf("Expected default port 587, got %d", config.Port)
+	}
+	if config.TLSMode != TLSModeSTARTTLS {
+		t.Errorf("Expected default mode starttls, got %s", config.TLSMode)
+	}
+}
+
+func TestPrepare_RejectsAuthWithoutTLS(t *testing.T) {
+	config := &SMTPConfig{
+		Host:     "relay.internal",
+		Port:     1025,
+		Username: "user",
+		Password: "secret",
+		Enabled:  true,
+		TLSMode:  TLSModeNone,
+	}
+
+	err := prepareSMTPConfig(config)
+	if err == nil {
+		t.Fatal("Expected error when credentials are used without TLS")
+	}
+	if !strings.Contains(err.Error(), "requires TLS") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestPrepare_AllowsNoTLSWithoutCredentials(t *testing.T) {
+	config := &SMTPConfig{Host: "mailpit", Port: 1025, Enabled: true, TLSMode: TLSModeNone}
+
+	if err := prepareSMTPConfig(config); err != nil {
+		t.Fatalf("Expected no error for credential-less plaintext relay, got: %v", err)
+	}
+}
+
+func TestGetSMTPConfig_TLSSettingsFromDatabase(t *testing.T) {
+	db := setupEmailTestDB(t)
+	defer db.Close()
+
+	t.Setenv("SMTP_HOST", "")
+	t.Setenv("SMTP_TLS_MODE", "")
+	t.Setenv("SMTP_TLS_SKIP_VERIFY", "")
+
+	settings := map[string]string{
+		"smtp_host":            "mailpit",
+		"smtp_port":            "1025",
+		"smtp_enabled":         "true",
+		"smtp_tls_mode":        TLSModeNone,
+		"smtp_tls_skip_verify": "true",
+	}
+	for k, v := range settings {
+		if _, err := db.Exec("INSERT INTO system_settings (key, value) VALUES (?, ?)", k, v); err != nil {
+			t.Fatalf("Failed to insert setting %s: %v", k, err)
+		}
+	}
+
+	svc := NewEmailService(repository.NewSettingsRepository(db))
+	config, err := svc.GetSMTPConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetSMTPConfig failed: %v", err)
+	}
+
+	if config.TLSMode != TLSModeNone {
+		t.Errorf("Expected TLS mode 'none', got '%s'", config.TLSMode)
+	}
+	if !config.TLSSkipVerify {
+		t.Error("Expected TLSSkipVerify to be true")
+	}
+}
+
+func TestGetSMTPConfig_TLSSettingsFromEnv(t *testing.T) {
+	db := setupEmailTestDB(t)
+	defer db.Close()
+
+	t.Setenv("SMTP_HOST", "mailpit")
+	t.Setenv("SMTP_PORT", "1025")
+	t.Setenv("SMTP_TLS_MODE", TLSModeNone)
+	t.Setenv("SMTP_TLS_SKIP_VERIFY", "true")
+
+	svc := NewEmailService(repository.NewSettingsRepository(db))
+	config, err := svc.GetSMTPConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetSMTPConfig failed: %v", err)
+	}
+
+	if config.TLSMode != TLSModeNone {
+		t.Errorf("Expected TLS mode 'none', got '%s'", config.TLSMode)
+	}
+	if !config.TLSSkipVerify {
+		t.Error("Expected TLSSkipVerify to be true")
+	}
+}
+
+func TestGetSMTPConfig_DatabaseSkipVerifyOverridesEnv(t *testing.T) {
+	db := setupEmailTestDB(t)
+	defer db.Close()
+
+	t.Setenv("SMTP_HOST", "mailpit")
+	t.Setenv("SMTP_TLS_SKIP_VERIFY", "true")
+
+	if _, err := db.Exec("INSERT INTO system_settings (key, value) VALUES (?, ?)", "smtp_tls_skip_verify", "false"); err != nil {
+		t.Fatalf("Failed to insert setting: %v", err)
+	}
+
+	svc := NewEmailService(repository.NewSettingsRepository(db))
+	config, err := svc.GetSMTPConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetSMTPConfig failed: %v", err)
+	}
+
+	if config.TLSSkipVerify {
+		t.Error("Expected database value 'false' to override env var")
+	}
+}
+
+// startFakeSMTP starts a plaintext SMTP server that never advertises STARTTLS.
+// The returned channel receives the body of the first delivered message.
+func startFakeSMTP(t *testing.T) (host string, port int, delivered <-chan string) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to start fake SMTP server: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	out := make(chan string, 1)
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		write := func(s string) {
+			conn.Write([]byte(s + "\r\n"))
+		}
+
+		write("220 fake ESMTP")
+
+		var body strings.Builder
+		inData := false
+
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+
+			if inData {
+				if line == "." {
+					inData = false
+					write("250 OK")
+					out <- body.String()
+					continue
+				}
+				body.WriteString(line + "\n")
+				continue
+			}
+
+			switch {
+			case strings.HasPrefix(line, "DATA"):
+				inData = true
+				write("354 Send data")
+			case strings.HasPrefix(line, "QUIT"):
+				write("221 Bye")
+				return
+			default:
+				write("250 OK")
+			}
+		}
+	}()
+
+	return "127.0.0.1", ln.Addr().(*net.TCPAddr).Port, out
+}
+
+func TestSendEmail_PlaintextRelay(t *testing.T) {
+	db := setupEmailTestDB(t)
+	defer db.Close()
+
+	host, port, delivered := startFakeSMTP(t)
+
+	t.Setenv("SMTP_HOST", host)
+	t.Setenv("SMTP_PORT", strconv.Itoa(port))
+	t.Setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+	t.Setenv("SMTP_TLS_MODE", TLSModeNone)
+	t.Setenv("SMTP_USERNAME", "")
+	t.Setenv("SMTP_PASSWORD", "")
+
+	svc := NewEmailService(repository.NewSettingsRepository(db))
+
+	if err := svc.SendEmail(context.Background(), "user@example.com", "Test subject", "<p>Hello</p>"); err != nil {
+		t.Fatalf("SendEmail failed: %v", err)
+	}
+
+	select {
+	case msg := <-delivered:
+		if !strings.Contains(msg, "Subject: Test subject") {
+			t.Errorf("Delivered message missing subject:\n%s", msg)
+		}
+		if !strings.Contains(msg, "<p>Hello</p>") {
+			t.Errorf("Delivered message missing body:\n%s", msg)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for delivered message")
+	}
+}
+
+func TestSendEmail_STARTTLSRequiredOnServerWithoutSupport(t *testing.T) {
+	db := setupEmailTestDB(t)
+	defer db.Close()
+
+	host, port, _ := startFakeSMTP(t)
+
+	t.Setenv("SMTP_HOST", host)
+	t.Setenv("SMTP_PORT", strconv.Itoa(port))
+	t.Setenv("SMTP_FROM_EMAIL", "noreply@example.com")
+	t.Setenv("SMTP_TLS_MODE", TLSModeSTARTTLS)
+	t.Setenv("SMTP_USERNAME", "")
+	t.Setenv("SMTP_PASSWORD", "")
+
+	svc := NewEmailService(repository.NewSettingsRepository(db))
+
+	err := svc.SendEmail(context.Background(), "user@example.com", "Test subject", "<p>Hello</p>")
+	if err == nil {
+		t.Fatal("Expected STARTTLS mode to fail against a server without STARTTLS")
+	}
+	if !strings.Contains(err.Error(), "does not support STARTTLS") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestGetSMTPConfig_NoTLSIgnoresEnvCredentials(t *testing.T) {
+	db := setupEmailTestDB(t)
+	defer db.Close()
+
+	t.Setenv("SMTP_HOST", "mailpit")
+	t.Setenv("SMTP_PORT", "1025")
+	t.Setenv("SMTP_TLS_MODE", TLSModeNone)
+	t.Setenv("SMTP_USERNAME", "leftover")
+	t.Setenv("SMTP_PASSWORD", "leftover")
+
+	svc := NewEmailService(repository.NewSettingsRepository(db))
+	config, err := svc.GetSMTPConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetSMTPConfig failed: %v", err)
+	}
+
+	if config.Username != "" || config.Password != "" {
+		t.Errorf("Expected env credentials to be ignored without TLS, got '%s'/'%s'", config.Username, config.Password)
+	}
+	if err := prepareSMTPConfig(config); err != nil {
+		t.Errorf("Expected an unencrypted relay to be usable, got: %v", err)
 	}
 }

--- a/backend/internal/services/email_service_test.go
+++ b/backend/internal/services/email_service_test.go
@@ -269,7 +269,7 @@ func TestTestConnectionWithConfig_NotConfigured(t *testing.T) {
 	repo := repository.NewSettingsRepository(db)
 	svc := NewEmailService(repo)
 
-	err := svc.TestConnectionWithConfig(&SMTPConfig{})
+	err := svc.TestConnectionWithConfig(context.Background(), &SMTPConfig{})
 	if err == nil {
 		t.Error("Expected error for unconfigured SMTP")
 	}
@@ -285,7 +285,7 @@ func TestTestConnectionWithConfig_DisabledSMTP(t *testing.T) {
 	repo := repository.NewSettingsRepository(db)
 	svc := NewEmailService(repo)
 
-	err := svc.TestConnectionWithConfig(&SMTPConfig{
+	err := svc.TestConnectionWithConfig(context.Background(), &SMTPConfig{
 		Host:    "smtp.example.com",
 		Enabled: false,
 	})
@@ -356,21 +356,36 @@ func TestPrepare_AppliesDefaults(t *testing.T) {
 }
 
 func TestPrepare_RejectsAuthWithoutTLS(t *testing.T) {
-	config := &SMTPConfig{
-		Host:     "relay.internal",
-		Port:     1025,
-		Username: "user",
-		Password: "secret",
-		Enabled:  true,
-		TLSMode:  TLSModeNone,
+	// A partially filled credential is a misconfiguration, not a reason to skip auth
+	tests := []struct {
+		name     string
+		username string
+		password string
+	}{
+		{"both", "user", "secret"},
+		{"username only", "user", ""},
+		{"password only", "", "secret"},
 	}
 
-	err := prepareSMTPConfig(config)
-	if err == nil {
-		t.Fatal("Expected error when credentials are used without TLS")
-	}
-	if !strings.Contains(err.Error(), "requires TLS") {
-		t.Errorf("Unexpected error: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &SMTPConfig{
+				Host:     "relay.internal",
+				Port:     1025,
+				Username: tt.username,
+				Password: tt.password,
+				Enabled:  true,
+				TLSMode:  TLSModeNone,
+			}
+
+			err := prepareSMTPConfig(config)
+			if err == nil {
+				t.Fatal("Expected error when credentials are used without TLS")
+			}
+			if !strings.Contains(err.Error(), "requires TLS") {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,15 @@ services:
       DB_HOST: db
       # Public URL for password reset emails and OAuth redirects:
       # FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+      # SMTP for password reset emails (or configure via Admin Settings):
+      # SMTP_HOST: ${SMTP_HOST:-}
+      # SMTP_PORT: ${SMTP_PORT:-}
+      # SMTP_USERNAME: ${SMTP_USERNAME:-}
+      # SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      # SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL:-}
+      # SMTP_FROM_NAME: ${SMTP_FROM_NAME:-}
+      # SMTP_TLS_MODE: ${SMTP_TLS_MODE:-}
+      # SMTP_TLS_SKIP_VERIFY: ${SMTP_TLS_SKIP_VERIFY:-}
       # Generic OIDC (Keycloak, Authentik, Dex, etc.):
       # OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-}
       # OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}

--- a/frontend/components/SMTPSettingsSection.tsx
+++ b/frontend/components/SMTPSettingsSection.tsx
@@ -4,7 +4,12 @@ import { useState, useEffect } from 'react'
 import { ThemedInput } from '@/components/ui/ThemedInput'
 import { Toggle } from '@/components/ui/Toggle'
 import { api } from '@/lib/api'
-import type { SystemSetting, SMTPStatusResponse } from '@/types'
+import type {
+  SystemSetting,
+  SMTPStatusResponse,
+  SMTPTLSMode,
+  UpdateSMTPSettingsRequest,
+} from '@/types'
 
 const SMTP_KEYS = [
   'smtp_host',
@@ -14,9 +19,23 @@ const SMTP_KEYS = [
   'smtp_from_email',
   'smtp_from_name',
   'smtp_enabled',
+  'smtp_tls_mode',
+  'smtp_tls_skip_verify',
 ] as const
 
 type SMTPKey = (typeof SMTP_KEYS)[number]
+
+const BOOLEAN_KEYS: SMTPKey[] = ['smtp_enabled', 'smtp_tls_skip_verify']
+
+// '' lets the backend pick: implicit TLS on port 465, STARTTLS elsewhere
+type TLSSelection = SMTPTLSMode | ''
+
+const TLS_MODES: { value: TLSSelection; label: string }[] = [
+  { value: '', label: 'Automatic (based on port)' },
+  { value: 'starttls', label: 'STARTTLS' },
+  { value: 'tls', label: 'Implicit TLS (port 465)' },
+  { value: 'none', label: 'None (unencrypted)' },
+]
 
 interface SMTPFormData {
   smtp_host: string
@@ -26,6 +45,8 @@ interface SMTPFormData {
   smtp_from_email: string
   smtp_from_name: string
   smtp_enabled: boolean
+  smtp_tls_mode: TLSSelection
+  smtp_tls_skip_verify: boolean
 }
 
 const defaultFormData: SMTPFormData = {
@@ -36,6 +57,12 @@ const defaultFormData: SMTPFormData = {
   smtp_from_email: '',
   smtp_from_name: 'Nimbus',
   smtp_enabled: false,
+  smtp_tls_mode: '',
+  smtp_tls_skip_verify: false,
+}
+
+function toTLSSelection(value: string): TLSSelection {
+  return TLS_MODES.some((mode) => mode.value === value) ? (value as TLSSelection) : ''
 }
 
 export default function SMTPSettingsSection({ settings }: { settings: SystemSetting[] }) {
@@ -57,16 +84,31 @@ export default function SMTPSettingsSection({ settings }: { settings: SystemSett
   useEffect(() => {
     const data = { ...defaultFormData }
     for (const setting of settings) {
-      if (SMTP_KEYS.includes(setting.key as SMTPKey)) {
-        if (setting.key === 'smtp_enabled') {
-          data.smtp_enabled = setting.value === 'true'
-        } else {
-          ;(data as Record<string, string | boolean>)[setting.key] = setting.value
-        }
+      const key = setting.key as SMTPKey
+      if (!SMTP_KEYS.includes(key)) continue
+
+      if (key === 'smtp_tls_mode') {
+        data.smtp_tls_mode = toTLSSelection(setting.value)
+      } else if (BOOLEAN_KEYS.includes(key)) {
+        ;(data as Record<string, string | boolean>)[key] = setting.value === 'true'
+      } else {
+        ;(data as Record<string, string | boolean>)[key] = setting.value
       }
     }
     setFormData(data)
   }, [settings])
+
+  const buildPayload = (): UpdateSMTPSettingsRequest => ({
+    smtp_host: formData.smtp_host,
+    smtp_port: formData.smtp_port,
+    smtp_username: formData.smtp_username,
+    smtp_password: formData.smtp_password,
+    smtp_from_email: formData.smtp_from_email,
+    smtp_from_name: formData.smtp_from_name,
+    smtp_enabled: String(formData.smtp_enabled),
+    smtp_tls_mode: formData.smtp_tls_mode,
+    smtp_tls_skip_verify: String(formData.smtp_tls_skip_verify),
+  })
 
   const handleSave = async () => {
     setIsSaving(true)
@@ -74,15 +116,7 @@ export default function SMTPSettingsSection({ settings }: { settings: SystemSett
     setSuccess('')
 
     try {
-      const response = await api.updateSMTPSettings({
-        smtp_host: formData.smtp_host,
-        smtp_port: formData.smtp_port,
-        smtp_username: formData.smtp_username,
-        smtp_password: formData.smtp_password,
-        smtp_from_email: formData.smtp_from_email,
-        smtp_from_name: formData.smtp_from_name,
-        smtp_enabled: String(formData.smtp_enabled),
-      })
+      const response = await api.updateSMTPSettings(buildPayload())
       if (response.error) {
         setError(response.error.message)
       } else {
@@ -101,15 +135,7 @@ export default function SMTPSettingsSection({ settings }: { settings: SystemSett
     setSuccess('')
 
     try {
-      const response = await api.testSMTPConnection({
-        smtp_host: formData.smtp_host,
-        smtp_port: formData.smtp_port,
-        smtp_username: formData.smtp_username,
-        smtp_password: formData.smtp_password,
-        smtp_from_email: formData.smtp_from_email,
-        smtp_from_name: formData.smtp_from_name,
-        smtp_enabled: String(formData.smtp_enabled),
-      })
+      const response = await api.testSMTPConnection(buildPayload())
       if (response.data?.success) {
         setSuccess('SMTP connection successful')
       } else {
@@ -220,6 +246,31 @@ export default function SMTPSettingsSection({ settings }: { settings: SystemSett
         </div>
         <div>
           <label
+            htmlFor="smtp-tls-mode"
+            className="mb-1 block text-xs font-medium"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            Encryption
+          </label>
+          <select
+            id="smtp-tls-mode"
+            value={formData.smtp_tls_mode}
+            onChange={(e) => updateField('smtp_tls_mode', e.target.value)}
+            className="border-card-border focus:border-primary focus:ring-opacity-50 w-full rounded-md border px-4 py-2 transition focus:ring-2 focus:outline-none"
+            style={{
+              backgroundColor: 'var(--color-background)',
+              color: 'var(--color-text-primary)',
+            }}
+          >
+            {TLS_MODES.map((mode) => (
+              <option key={mode.value} value={mode.value}>
+                {mode.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label
             htmlFor="smtp-username"
             className="mb-1 block text-xs font-medium"
             style={{ color: 'var(--color-text-secondary)' }}
@@ -281,6 +332,23 @@ export default function SMTPSettingsSection({ settings }: { settings: SystemSett
           />
         </div>
       </div>
+
+      {formData.smtp_tls_mode === 'none' ? (
+        <div
+          className="rounded-lg p-3 text-sm"
+          style={{ backgroundColor: 'var(--color-error)', color: 'white', opacity: 0.9 }}
+        >
+          Emails are sent unencrypted. Only use this for a relay on a trusted network. Username and
+          password must be left empty, since they would be sent in cleartext.
+        </div>
+      ) : (
+        <Toggle
+          enabled={formData.smtp_tls_skip_verify}
+          onChange={(enabled) => updateField('smtp_tls_skip_verify', enabled)}
+          label="Skip certificate verification"
+          description="Allows self-signed certificates. Leave off unless your relay needs it."
+        />
+      )}
 
       <div className="flex space-x-3">
         <button

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -350,6 +350,8 @@ export interface SMTPStatusResponse {
   source: 'env' | 'database' | 'none'
 }
 
+export type SMTPTLSMode = 'starttls' | 'tls' | 'none'
+
 export interface UpdateSMTPSettingsRequest {
   smtp_host: string
   smtp_port: string
@@ -358,6 +360,8 @@ export interface UpdateSMTPSettingsRequest {
   smtp_from_email: string
   smtp_from_name: string
   smtp_enabled: string
+  smtp_tls_mode: string
+  smtp_tls_skip_verify: string
 }
 
 // Setup types


### PR DESCRIPTION
Closes #184

## Problem

Outgoing mail always required encryption: port 465 used implicit TLS, and every other port required STARTTLS and errored out when the server did not advertise it. A local SMTP relay — Mailpit, or a dedicated relay container on an internal Docker network — could not be used at all.

## Changes

Two new settings, configurable through env vars or the admin UI:

- `SMTP_TLS_MODE` / `smtp_tls_mode` — `starttls`, `tls` or `none`
- `SMTP_TLS_SKIP_VERIFY` / `smtp_tls_skip_verify` — accept self-signed certificates

When the mode is unset, it falls back to the existing behaviour (implicit TLS on 465, STARTTLS elsewhere), so existing installs are unaffected and no migration is needed.

Credentials are rejected when the mode is `none`, both at save time and at send time, because Go's `PlainAuth` would otherwise transmit them in cleartext. Environment credentials are also ignored in that mode, so an admin who clears the fields for an unencrypted relay is not blocked by leftovers in `SMTP_USERNAME`.

Two smaller fixes came out of building this:

- The two send paths were near-identical; they now share a single dial and deliver flow, which also removed the duplicate copy inside `TestConnectionWithConfig`.
- Only the TCP dial was bounded by a timeout. A port that accepts a connection but never sends a greeting — a TLS-only port probed in plaintext, which the mode selector now makes reachable from the UI — blocked the request goroutine forever. The socket now carries a 30s session deadline.

`SMTP_*` variables were also added to `docker-compose.yml` (commented out), since the service enumerates its environment explicitly and none of them reached the container before.

## Admin UI

An "Encryption" dropdown next to the port field, defaulting to "Automatic (based on port)". Selecting "None (unencrypted)" replaces the certificate toggle with a warning that mail is sent unencrypted and credentials must be left empty.

## Testing

`make ci-check` passes. New coverage includes an end-to-end send against an in-test SMTP server that never advertises STARTTLS, which fails on `starttls` and succeeds on `none`, plus mode resolution, the credential guard, and the handler validation paths.

The 30s deadline fix was verified separately against a listener that accepts and then stays silent: it now returns `i/o timeout` after 30s where it previously never returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMTP encryption mode selection: STARTTLS, implicit TLS, or unencrypted.
  * Added an option to skip certificate verification for encrypted SMTP connections.
  * SMTP settings now preserve existing TLS values when fields are omitted.
  * Added validation and warnings for unsupported configurations, including credentials with unencrypted SMTP.
  * SMTP connection testing now uses the selected encryption and certificate settings.
  * Added SMTP configuration examples for environment and container deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->