### PR TITLE
fix(docker): migrate cluster nested at PGDATA/data by old pg18 symlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Test entrypoint script
         run: sh docker/entrypoint.test.sh
 
+      - name: Test postgres entrypoint script
+        run: sh docker/postgres/entrypoint.test.sh
+
   # nimbus.turboot.com prod image
   docker-demo:
     name: Build Demo Image

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ clean:
 test-docker:
 	@echo "🐳 Testing Docker scripts..."
 	@sh docker/entrypoint.test.sh
+	@sh docker/postgres/entrypoint.test.sh
 	@echo ""
 
 # Run all CI checks locally (same as GitHub Actions)
@@ -138,6 +139,7 @@ ci-check:
 	@echo ""
 	@echo "🐳 Docker script checks..."
 	@sh docker/entrypoint.test.sh
+	@sh docker/postgres/entrypoint.test.sh
 	@echo ""
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo "✅ All CI checks passed!"

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -36,14 +36,44 @@ if [ -f "$SETUP_MARKER" ]; then
     else
         # Retry loop for database readiness
         USER_COUNT="error"
+        PSQL_ERR=""
+        PSQL_ERR_FILE=$(mktemp)
         for i in 1 2 3; do
-            USER_COUNT=$(PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT COUNT(*) FROM users;" 2>/dev/null || echo "error")
-            [ "$USER_COUNT" != "error" ] && break
+            if PSQL_OUT=$(PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT COUNT(*) FROM users;" 2>"$PSQL_ERR_FILE"); then
+                USER_COUNT="$PSQL_OUT"
+                break
+            fi
+            PSQL_ERR=$(cat "$PSQL_ERR_FILE")
             sleep 2
         done
+        rm -f "$PSQL_ERR_FILE"
     fi
 
-    if [ "$USER_COUNT" = "0" ] || [ "$USER_COUNT" = "error" ]; then
+    if [ "$USER_COUNT" = "error" ]; then
+        echo ""
+        echo "============================================================"
+        echo "  ERROR: Cannot query the Nimbus database!"
+        echo "============================================================"
+        echo ""
+        echo "  psql said: ${PSQL_ERR}"
+        echo ""
+        echo "  The database container is likely down or failing to start."
+        echo "  Check its logs first: docker logs nimbus-db"
+        echo ""
+        echo "  If those logs show 'directory exists but is not empty',"
+        echo "  pull the latest db image and restart - Nimbus migrates"
+        echo "  your data automatically:"
+        echo ""
+        echo "    docker-compose pull db && docker-compose up -d"
+        echo ""
+        echo "  To skip this check: SKIP_DB_CHECK=true"
+        echo "============================================================"
+        echo ""
+
+        if [ "${SKIP_DB_CHECK}" != "true" ]; then
+            exit 1
+        fi
+    elif [ "$USER_COUNT" = "0" ]; then
         echo ""
         echo "============================================================"
         echo "  ERROR: Database appears empty but Nimbus was initialized!"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,14 +66,44 @@ if [ -f "$SETUP_MARKER" ]; then
     else
         # Retry loop for database readiness (postgres may need time after connection is ready)
         USER_COUNT="error"
+        PSQL_ERR=""
+        PSQL_ERR_FILE=$(mktemp)
         for i in 1 2 3; do
-            USER_COUNT=$(PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT COUNT(*) FROM users;" 2>/dev/null || echo "error")
-            [ "$USER_COUNT" != "error" ] && break
+            if PSQL_OUT=$(PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT COUNT(*) FROM users;" 2>"$PSQL_ERR_FILE"); then
+                USER_COUNT="$PSQL_OUT"
+                break
+            fi
+            PSQL_ERR=$(cat "$PSQL_ERR_FILE")
             sleep 2
         done
+        rm -f "$PSQL_ERR_FILE"
     fi
 
-    if [ "$USER_COUNT" = "0" ] || [ "$USER_COUNT" = "error" ]; then
+    if [ "$USER_COUNT" = "error" ]; then
+        echo ""
+        echo "============================================================"
+        echo "  ERROR: Cannot query the Nimbus database!"
+        echo "============================================================"
+        echo ""
+        echo "  psql said: ${PSQL_ERR}"
+        echo ""
+        echo "  The database container is likely down or failing to start."
+        echo "  Check its logs first: docker logs nimbus-db"
+        echo ""
+        echo "  If those logs show 'directory exists but is not empty',"
+        echo "  pull the latest db image and restart - Nimbus migrates"
+        echo "  your data automatically:"
+        echo ""
+        echo "    docker-compose pull db && docker-compose up -d"
+        echo ""
+        echo "  To skip this check: SKIP_DB_CHECK=true"
+        echo "============================================================"
+        echo ""
+
+        if [ "${SKIP_DB_CHECK}" != "true" ]; then
+            exit 1
+        fi
+    elif [ "$USER_COUNT" = "0" ]; then
         echo ""
         echo "============================================================"
         echo "  ERROR: Database appears empty but Nimbus was initialized!"

--- a/docker/postgres/entrypoint.sh
+++ b/docker/postgres/entrypoint.sh
@@ -58,6 +58,20 @@ nimbus_migrate_legacy_data() {
 
     if [ -n "$LEGACY_DIR" ] && [ ! -f "$PGDATA/PG_VERSION" ]; then
         echo "Nimbus: Migrating PostgreSQL data from legacy location ($LEGACY_DIR)..."
+
+        # Refuse to merge into existing entries - a collision means $PGDATA
+        # holds leftovers of another (partial) cluster; moving would interleave them
+        for entry in "$LEGACY_DIR"/* "$LEGACY_DIR"/.[!.]*; do
+            [ -e "$entry" ] || continue
+            name=$(basename "$entry")
+            [ "$PGDATA/$name" = "$LEGACY_DIR" ] && continue
+            if [ -e "$PGDATA/$name" ]; then
+                echo "Nimbus: ERROR - Cannot migrate: $PGDATA already contains '$name'"
+                echo "Nimbus: Resolve manually, nothing was moved."
+                exit 1
+            fi
+        done
+
         src_count=$(ls -1A "$LEGACY_DIR" | wc -l)
         initial_dest_count=$(ls -1A "$PGDATA" | wc -l)
 
@@ -82,11 +96,11 @@ nimbus_migrate_legacy_data() {
             exit 1
         fi
 
-        # Safe to remove source now
+        # Safe to remove the emptied legacy dir now; only remove its parent
+        # (the 18/ dir) when nothing else lives there
+        rm -rf "$LEGACY_DIR"
         case "$LEGACY_DIR" in
-            "$PGDATA/18/docker") rm -rf "$PGDATA/18" ;;
-            "$PGDATA/data")      rm -rf "$PGDATA/data" ;;
-            *)                   rm -rf "$NIMBUS_PG_ROOT/18" ;;
+            */18/docker) rmdir "$(dirname "$LEGACY_DIR")" 2>/dev/null || true ;;
         esac
         if [ "$(id -u)" = "0" ]; then
             chown -R postgres:postgres "$PGDATA"

--- a/docker/postgres/entrypoint.sh
+++ b/docker/postgres/entrypoint.sh
@@ -1,85 +1,107 @@
 #!/bin/sh
 set -e
 
-# Validate PGDATA is set to the correct path (not the postgres:18-alpine default)
+# Overridable in tests (NIMBUS_ENTRYPOINT_TEST); defaults match the real container
+NIMBUS_PG_ROOT="${NIMBUS_PG_ROOT:-/var/lib/postgresql}"
 EXPECTED_PGDATA="/var/lib/postgresql/data"
-if [ "$PGDATA" != "$EXPECTED_PGDATA" ]; then
-    echo ""
-    echo "============================================================"
-    echo "  Nimbus: docker-compose.yml update required!"
-    echo "============================================================"
-    echo ""
-    echo "  Your docker-compose.yml is outdated. Please add PGDATA"
-    echo "  to your db service environment:"
-    echo ""
-    echo "    db:"
-    echo "      image: turboot/nimbus-postgres:18"
-    echo "      environment:"
-    echo "        PGDATA: /var/lib/postgresql/data   # <-- add this"
-    echo "        ..."
-    echo ""
-    echo "  Current PGDATA: $PGDATA"
-    echo "  Expected PGDATA: $EXPECTED_PGDATA"
-    echo ""
-    echo "  Then run: docker-compose up -d"
-    echo ""
-    echo "============================================================"
-    echo ""
-    exit 1
-fi
 
-# Ensure PGDATA directory exists
-mkdir -p "$PGDATA"
-
-# Check for legacy data in two possible locations:
-# 1. /var/lib/postgresql/18/docker (outside volume - unlikely)
-# 2. $PGDATA/18/docker (inside volume - common scenario)
-LEGACY_DIR=""
-if [ -f "/var/lib/postgresql/18/docker/PG_VERSION" ]; then
-    LEGACY_DIR="/var/lib/postgresql/18/docker"
-elif [ -f "$PGDATA/18/docker/PG_VERSION" ]; then
-    LEGACY_DIR="$PGDATA/18/docker"
-fi
-
-# Auto-migrate data from legacy PostgreSQL 18 location if needed
-if [ -n "$LEGACY_DIR" ] && [ ! -f "$PGDATA/PG_VERSION" ]; then
-    echo "Nimbus: Migrating PostgreSQL data from legacy location..."
-    src_count=$(ls -1A "$LEGACY_DIR" | wc -l)
-    initial_dest_count=$(ls -1A "$PGDATA" | wc -l)
-
-    # Move regular files/dirs
-    if ! mv "$LEGACY_DIR"/* "$PGDATA/"; then
-        echo "Nimbus: ERROR - Failed to move files from $LEGACY_DIR"
+# Validate PGDATA is set to the correct path (not the postgres:18-alpine default)
+nimbus_validate_pgdata() {
+    if [ "$PGDATA" != "$EXPECTED_PGDATA" ]; then
+        echo ""
+        echo "============================================================"
+        echo "  Nimbus: docker-compose.yml update required!"
+        echo "============================================================"
+        echo ""
+        echo "  Your docker-compose.yml is outdated. Please add PGDATA"
+        echo "  to your db service environment:"
+        echo ""
+        echo "    db:"
+        echo "      image: turboot/nimbus-postgres:18"
+        echo "      environment:"
+        echo "        PGDATA: /var/lib/postgresql/data   # <-- add this"
+        echo "        ..."
+        echo ""
+        echo "  Current PGDATA: $PGDATA"
+        echo "  Expected PGDATA: $EXPECTED_PGDATA"
+        echo ""
+        echo "  Then run: docker-compose up -d"
+        echo ""
+        echo "============================================================"
+        echo ""
         exit 1
     fi
+}
 
-    # Move hidden files (may not exist, so check first)
-    for f in "$LEGACY_DIR"/.[!.]*; do
-        if [ -e "$f" ]; then
-            mv "$f" "$PGDATA/" || { echo "Nimbus: ERROR - Failed to move $f"; exit 1; }
+# Detect a cluster left behind by older image layouts and move it to $PGDATA.
+# Known legacy locations:
+# 1. <pg root>/18/docker           - postgres:18 default PGDATA, outside volume
+# 2. $PGDATA/18/docker             - same, but nested inside the volume
+# 3. $PGDATA/data                  - created by old postgres:18 images that shipped
+#                                    a /var/lib/postgresql/data -> . compat symlink;
+#                                    mounting the volume there landed it on the parent,
+#                                    so the cluster was initialized one level deeper
+nimbus_migrate_legacy_data() {
+    mkdir -p "$PGDATA"
+
+    # Remove stale compat symlink (data -> .) copied in from old postgres:18 images
+    [ -L "$PGDATA/data" ] && rm "$PGDATA/data"
+
+    LEGACY_DIR=""
+    if [ -f "$NIMBUS_PG_ROOT/18/docker/PG_VERSION" ]; then
+        LEGACY_DIR="$NIMBUS_PG_ROOT/18/docker"
+    elif [ -f "$PGDATA/18/docker/PG_VERSION" ]; then
+        LEGACY_DIR="$PGDATA/18/docker"
+    elif [ -f "$PGDATA/data/PG_VERSION" ]; then
+        LEGACY_DIR="$PGDATA/data"
+    fi
+
+    if [ -n "$LEGACY_DIR" ] && [ ! -f "$PGDATA/PG_VERSION" ]; then
+        echo "Nimbus: Migrating PostgreSQL data from legacy location ($LEGACY_DIR)..."
+        src_count=$(ls -1A "$LEGACY_DIR" | wc -l)
+        initial_dest_count=$(ls -1A "$PGDATA" | wc -l)
+
+        # Move regular files/dirs
+        if ! mv "$LEGACY_DIR"/* "$PGDATA/"; then
+            echo "Nimbus: ERROR - Failed to move files from $LEGACY_DIR"
+            exit 1
         fi
-    done
 
-    # Verify migration succeeded by checking delta
-    dest_count=$(ls -1A "$PGDATA" | wc -l)
-    moved_count=$((dest_count - initial_dest_count))
-    if [ "$moved_count" -lt "$src_count" ]; then
-        echo "Nimbus: ERROR - Migration verification failed (expected $src_count items, moved $moved_count)"
-        exit 1
-    fi
+        # Move hidden files (may not exist, so check first)
+        for f in "$LEGACY_DIR"/.[!.]*; do
+            if [ -e "$f" ]; then
+                mv "$f" "$PGDATA/" || { echo "Nimbus: ERROR - Failed to move $f"; exit 1; }
+            fi
+        done
 
-    # Safe to remove source now
-    if [ "$LEGACY_DIR" = "$PGDATA/18/docker" ]; then
-        rm -rf "$PGDATA/18"
-    else
-        rm -rf /var/lib/postgresql/18
+        # Verify migration succeeded by checking delta
+        dest_count=$(ls -1A "$PGDATA" | wc -l)
+        moved_count=$((dest_count - initial_dest_count))
+        if [ "$moved_count" -lt "$src_count" ]; then
+            echo "Nimbus: ERROR - Migration verification failed (expected $src_count items, moved $moved_count)"
+            exit 1
+        fi
+
+        # Safe to remove source now
+        case "$LEGACY_DIR" in
+            "$PGDATA/18/docker") rm -rf "$PGDATA/18" ;;
+            "$PGDATA/data")      rm -rf "$PGDATA/data" ;;
+            *)                   rm -rf "$NIMBUS_PG_ROOT/18" ;;
+        esac
+        if [ "$(id -u)" = "0" ]; then
+            chown -R postgres:postgres "$PGDATA"
+        fi
+        echo "Nimbus: Migration complete! Moved $src_count items."
+    elif [ -f "$PGDATA/PG_VERSION" ] && [ -f "$PGDATA/data/PG_VERSION" ]; then
+        echo "Nimbus: WARNING - Found clusters at both \$PGDATA and \$PGDATA/data; using \$PGDATA."
     fi
-    chown -R postgres:postgres "$PGDATA"
-    echo "Nimbus: Migration complete! Moved $src_count items."
+}
+
+# Skip execution when sourced by tests
+if [ -z "${NIMBUS_ENTRYPOINT_TEST:-}" ]; then
+    nimbus_validate_pgdata
+    nimbus_migrate_legacy_data
+
+    # Run original postgres entrypoint
+    exec docker-entrypoint.sh "$@"
 fi
-
-# Remove problematic symlink if present
-[ -L "$PGDATA/data" ] && rm "$PGDATA/data"
-
-# Run original postgres entrypoint
-exec docker-entrypoint.sh "$@"

--- a/docker/postgres/entrypoint.sh
+++ b/docker/postgres/entrypoint.sh
@@ -61,11 +61,11 @@ nimbus_migrate_legacy_data() {
 
         # Refuse to merge into existing entries - a collision means $PGDATA
         # holds leftovers of another (partial) cluster; moving would interleave them
-        for entry in "$LEGACY_DIR"/* "$LEGACY_DIR"/.[!.]*; do
-            [ -e "$entry" ] || continue
+        for entry in "$LEGACY_DIR"/* "$LEGACY_DIR"/.[!.]* "$LEGACY_DIR"/..?*; do
+            [ -e "$entry" ] || [ -L "$entry" ] || continue
             name=$(basename "$entry")
             [ "$PGDATA/$name" = "$LEGACY_DIR" ] && continue
-            if [ -e "$PGDATA/$name" ]; then
+            if [ -e "$PGDATA/$name" ] || [ -L "$PGDATA/$name" ]; then
                 echo "Nimbus: ERROR - Cannot migrate: $PGDATA already contains '$name'"
                 echo "Nimbus: Resolve manually, nothing was moved."
                 exit 1
@@ -82,8 +82,8 @@ nimbus_migrate_legacy_data() {
         fi
 
         # Move hidden files (may not exist, so check first)
-        for f in "$LEGACY_DIR"/.[!.]*; do
-            if [ -e "$f" ]; then
+        for f in "$LEGACY_DIR"/.[!.]* "$LEGACY_DIR"/..?*; do
+            if [ -e "$f" ] || [ -L "$f" ]; then
                 mv "$f" "$PGDATA/" || { echo "Nimbus: ERROR - Failed to move $f"; exit 1; }
             fi
         done

--- a/docker/postgres/entrypoint.test.sh
+++ b/docker/postgres/entrypoint.test.sh
@@ -169,7 +169,45 @@ test_fresh_empty_pgdata() {
 }
 
 # =============================================================================
-# Test 8: PGDATA validation rejects wrong path
+# Test 8: Migration aborts on destination collision without moving anything
+# =============================================================================
+test_collision_aborts_migration() {
+    setup
+    make_cluster "$PGDATA/data"
+    mkdir -p "$PGDATA/base"
+    echo "keep" > "$PGDATA/base/leftover"
+
+    RESULT=$( (nimbus_migrate_legacy_data) 2>&1 )
+    STATUS=$?
+
+    if [ "$STATUS" -ne 0 ] && [ -f "$PGDATA/data/PG_VERSION" ] && [ -f "$PGDATA/base/leftover" ] && [ ! -f "$PGDATA/PG_VERSION" ]; then
+        pass "destination collision aborts migration, nothing moved"
+    else
+        fail "destination collision should abort migration untouched (status=$STATUS)"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 9: Cleanup keeps siblings next to 18/docker
+# =============================================================================
+test_cleanup_preserves_18_siblings() {
+    setup
+    make_cluster "$PGDATA/18/docker"
+    echo "keep" > "$PGDATA/18/sibling"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/PG_VERSION" ] && [ ! -d "$PGDATA/18/docker" ] && [ -f "$PGDATA/18/sibling" ]; then
+        pass "cleanup preserves sibling files under 18/"
+    else
+        fail "cleanup should preserve sibling files under 18/"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 10: PGDATA validation rejects wrong path
 # =============================================================================
 test_pgdata_validation() {
     setup
@@ -197,6 +235,8 @@ test_migrates_root_18_docker
 test_existing_root_cluster_untouched
 test_removes_stale_symlink
 test_fresh_empty_pgdata
+test_collision_aborts_migration
+test_cleanup_preserves_18_siblings
 test_pgdata_validation
 
 echo "================================"

--- a/docker/postgres/entrypoint.test.sh
+++ b/docker/postgres/entrypoint.test.sh
@@ -1,0 +1,207 @@
+#!/bin/sh
+# Tests for docker/postgres/entrypoint.sh legacy data migration logic
+# Run with: sh docker/postgres/entrypoint.test.sh
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ENTRYPOINT="${SCRIPT_DIR}/entrypoint.sh"
+
+pass() {
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    printf "${GREEN}✓ PASS${NC}: %s\n" "$1"
+}
+
+fail() {
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    printf "${RED}✗ FAIL${NC}: %s\n" "$1"
+}
+
+# Helper: set up a fresh fake volume dir and source the entrypoint functions
+setup() {
+    TEST_DIR=$(mktemp -d)
+    PG_ROOT="${TEST_DIR}/var-lib-postgresql"
+    PGDATA="${PG_ROOT}/data"
+    mkdir -p "$PG_ROOT"
+    export PGDATA
+    export NIMBUS_ENTRYPOINT_TEST=1
+    export NIMBUS_PG_ROOT="$PG_ROOT"
+    # shellcheck disable=SC1090
+    . "$ENTRYPOINT"
+    set +e  # sourcing the entrypoint enables set -e; tests need failures to be observable
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Helper: create a minimal fake postgres cluster in a directory
+make_cluster() {
+    mkdir -p "$1/base" "$1/global"
+    echo "18" > "$1/PG_VERSION"
+    echo "# config" > "$1/postgresql.conf"
+    touch "$1/.hidden_marker"
+}
+
+# =============================================================================
+# Test 1: Cluster nested at $PGDATA/data (postgres:18 compat-symlink era)
+# is migrated up to $PGDATA
+# =============================================================================
+test_migrates_nested_data_dir() {
+    setup
+    make_cluster "$PGDATA/data"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/PG_VERSION" ] && [ -d "$PGDATA/base" ] && [ ! -d "$PGDATA/data" ]; then
+        pass "cluster nested at \$PGDATA/data is migrated to \$PGDATA"
+    else
+        fail "cluster nested at \$PGDATA/data should be migrated to \$PGDATA"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 2: Hidden files survive the nested-data migration
+# =============================================================================
+test_migrates_hidden_files() {
+    setup
+    make_cluster "$PGDATA/data"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/.hidden_marker" ]; then
+        pass "hidden files are migrated from \$PGDATA/data"
+    else
+        fail "hidden files should be migrated from \$PGDATA/data"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 3: Cluster at $PGDATA/18/docker is migrated (existing behavior)
+# =============================================================================
+test_migrates_nested_18_docker() {
+    setup
+    make_cluster "$PGDATA/18/docker"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/PG_VERSION" ] && [ ! -d "$PGDATA/18" ]; then
+        pass "cluster at \$PGDATA/18/docker is migrated to \$PGDATA"
+    else
+        fail "cluster at \$PGDATA/18/docker should be migrated to \$PGDATA"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 4: Cluster at <pg root>/18/docker (outside volume) is migrated
+# =============================================================================
+test_migrates_root_18_docker() {
+    setup
+    mkdir -p "$PGDATA"
+    make_cluster "$PG_ROOT/18/docker"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/PG_VERSION" ] && [ ! -d "$PG_ROOT/18" ]; then
+        pass "cluster at <pg root>/18/docker is migrated to \$PGDATA"
+    else
+        fail "cluster at <pg root>/18/docker should be migrated to \$PGDATA"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 5: Existing cluster at $PGDATA root is left untouched
+# =============================================================================
+test_existing_root_cluster_untouched() {
+    setup
+    make_cluster "$PGDATA"
+    make_cluster "$PGDATA/data"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/PG_VERSION" ] && [ -f "$PGDATA/data/PG_VERSION" ]; then
+        pass "existing root cluster is not overwritten by nested data"
+    else
+        fail "existing root cluster should be left untouched"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 6: Stale compat symlink $PGDATA/data -> . is removed
+# =============================================================================
+test_removes_stale_symlink() {
+    setup
+    make_cluster "$PGDATA"
+    ln -s . "$PGDATA/data"
+
+    nimbus_migrate_legacy_data
+
+    if [ ! -L "$PGDATA/data" ] && [ -f "$PGDATA/PG_VERSION" ]; then
+        pass "stale \$PGDATA/data symlink is removed, cluster intact"
+    else
+        fail "stale \$PGDATA/data symlink should be removed without touching cluster"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 7: Fresh empty PGDATA does nothing and does not error
+# =============================================================================
+test_fresh_empty_pgdata() {
+    setup
+
+    if nimbus_migrate_legacy_data && [ -d "$PGDATA" ] && [ ! -f "$PGDATA/PG_VERSION" ]; then
+        pass "fresh empty PGDATA is a no-op"
+    else
+        fail "fresh empty PGDATA should be a no-op"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 8: PGDATA validation rejects wrong path
+# =============================================================================
+test_pgdata_validation() {
+    setup
+    RESULT=$(PGDATA="/wrong/path" sh -c ". '$ENTRYPOINT' && nimbus_validate_pgdata" 2>&1)
+    STATUS=$?
+
+    if [ "$STATUS" -ne 0 ] && echo "$RESULT" | grep -q "PGDATA"; then
+        pass "wrong PGDATA is rejected with an explanatory message"
+    else
+        fail "wrong PGDATA should be rejected (status=$STATUS)"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Run all tests
+# =============================================================================
+echo "Running docker/postgres/entrypoint.sh tests..."
+echo "================================"
+
+test_migrates_nested_data_dir
+test_migrates_hidden_files
+test_migrates_nested_18_docker
+test_migrates_root_18_docker
+test_existing_root_cluster_untouched
+test_removes_stale_symlink
+test_fresh_empty_pgdata
+test_pgdata_validation
+
+echo "================================"
+echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+
+if [ "${TESTS_FAILED}" -gt 0 ]; then
+    exit 1
+fi

--- a/docker/postgres/entrypoint.test.sh
+++ b/docker/postgres/entrypoint.test.sh
@@ -207,7 +207,45 @@ test_cleanup_preserves_18_siblings() {
 }
 
 # =============================================================================
-# Test 10: PGDATA validation rejects wrong path
+# Test 10: Dot-dot-prefixed entries and dangling symlinks are migrated
+# =============================================================================
+test_migrates_odd_entries() {
+    setup
+    make_cluster "$PGDATA/data"
+    echo "keep" > "$PGDATA/data/..legacy_marker"
+    ln -s /nonexistent "$PGDATA/data/dangling"
+
+    nimbus_migrate_legacy_data
+
+    if [ -f "$PGDATA/..legacy_marker" ] && [ -L "$PGDATA/dangling" ] && [ ! -d "$PGDATA/data" ]; then
+        pass "..-prefixed entries and dangling symlinks are migrated"
+    else
+        fail "..-prefixed entries and dangling symlinks should be migrated"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 11: Dangling destination symlink triggers collision abort
+# =============================================================================
+test_dangling_dest_symlink_collides() {
+    setup
+    make_cluster "$PGDATA/data"
+    ln -s /nonexistent "$PGDATA/base"
+
+    RESULT=$( (nimbus_migrate_legacy_data) 2>&1 )
+    STATUS=$?
+
+    if [ "$STATUS" -ne 0 ] && [ -f "$PGDATA/data/PG_VERSION" ]; then
+        pass "dangling destination symlink aborts migration"
+    else
+        fail "dangling destination symlink should abort migration (status=$STATUS)"
+    fi
+    teardown
+}
+
+# =============================================================================
+# Test 12: PGDATA validation rejects wrong path
 # =============================================================================
 test_pgdata_validation() {
     setup
@@ -237,6 +275,8 @@ test_removes_stale_symlink
 test_fresh_empty_pgdata
 test_collision_aborts_migration
 test_cleanup_preserves_18_siblings
+test_migrates_odd_entries
+test_dangling_dest_symlink_collides
 test_pgdata_validation
 
 echo "================================"


### PR DESCRIPTION
## Problem

Legacy (separate-container) stacks started crashlooping after the latest image rebuilds: the backend printed **"ERROR: Database appears empty but Nimbus was initialized!"** and login was down — while the data was still fully intact.

## Root cause

1. Old `postgres:18-alpine` base images shipped a compat symlink `/var/lib/postgresql/data -> .`
2. With the legacy compose (`postgres_data:/var/lib/postgresql/data`), Docker resolved that symlink at container create, so the volume actually mounted at `/var/lib/postgresql`.
3. Our entrypoint removes that "problematic symlink", after which the upstream entrypoint's `mkdir -p $PGDATA` recreated `data/` as a real directory **inside the volume** — the cluster was initialized nested at `volume/data/`.
4. Newer bases dropped the symlink. On the next CI rebuild + image pull, the volume mounts at the literal path, `PGDATA` becomes the volume root, initdb sees a non-empty dir (the stray `data/`) and postgres crashloops with `initdb: directory "/var/lib/postgresql/data" exists but is not empty`.
5. The backend couldn't reach the db and reported the misleading "database appears empty" error.

Reproduced end-to-end locally by initializing a cluster with a symlink-era base and then booting the current image on the same volume.

## Fix

- `docker/postgres/entrypoint.sh`: detect a cluster at `$PGDATA/data` (third legacy layout) and auto-migrate it up to `$PGDATA`, reusing the existing verified move logic. Idempotent; refuses to touch anything when a cluster already exists at `$PGDATA`.
- `backend/entrypoint.sh` + `docker/entrypoint.sh`: split the integrity-check error paths. An unreachable/unqueryable db now shows the actual psql error and points at `docker logs nimbus-db`, instead of claiming the database is empty. psql stderr is captured separately so warnings can't corrupt the user count.
- New test suite `docker/postgres/entrypoint.test.sh` (8 cases: nested `data/`, nested `18/docker`, root `18/docker`, hidden files, existing-cluster no-op, stale symlink, empty PGDATA, PGDATA validation), wired into CI and `make ci-check`.

## Verification

- All 8 new tests + existing 9 entrypoint tests pass; `make ci-check` green.
- Smoke-tested with the real legacy compose: nested-layout volume auto-migrates (24 items moved, data intact, `data/` cleaned up), restart is a no-op, integrity check reports `Database OK`, register + login return 200/201.
- Negative path: db down → backend prints the new "Cannot query" error with the psql message.

For affected users: `docker-compose pull db && docker-compose up -d` once this is released — data migrates automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup diagnostics with clearer error details when integrity checks fail.
  * Prevented startup from continuing after failed database checks unless explicitly configured to skip them.
  * Improved PostgreSQL data migration handling, including legacy locations, stale links, permissions, conflicting clusters, and collision safeguards.
  * Preserved neighboring data during legacy-directory cleanup.

* **Tests**
  * Added automated coverage for PostgreSQL data migration and configuration validation.
  * Included these checks in Docker and continuous integration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->